### PR TITLE
Added custom launchers for firefox and chrome, and debug-chrome and d…

### DIFF
--- a/webapp/karma.conf.js
+++ b/webapp/karma.conf.js
@@ -11,6 +11,7 @@ module.exports = function (config) {
     plugins: [
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
+      require('karma-firefox-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
       require('@angular-devkit/build-angular/plugins/karma')
@@ -29,6 +30,10 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
     autoWatch: true,
     browsers: ['ChromeHeadless'],
+    customLaunchers: {
+        ChromeDebug: { base: 'Chrome' }, 
+        FirefoxDebug: { base: 'Firefox' }
+    },
     singleRun: false,
     restartOnFileChange: true
   });

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -5311,6 +5311,12 @@
         "minimatch": "^3.0.4"
       }
     },
+    "karma-firefox-launcher": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-1.1.0.tgz",
+      "integrity": "sha512-LbZ5/XlIXLeQ3cqnCbYLn+rOVhuMIK9aZwlP6eOLGzWdo1UVp7t6CN3DP4SafiRLjexKwHeKHDm0c38Mtd3VxA==",
+      "dev": true
+    },
     "karma-jasmine": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-2.0.1.tgz",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -3,11 +3,13 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "npm run test && ng serve",
-    "start-standalone": "npm run test && ng serve --c standalone",
+    "start": "npm run test && ng serve -o",
+    "start-standalone": "npm run test && ng serve --c standalone -o",
     "build": "npm run test && ng build --prod --aot --vendor-chunk",
     "build-standalone": "npm run test && ng build --c standalone --aot --vendor-chunk",
     "test": "ng test --source-map=false --watch=false",
+    "test-debug-chrome": "ng test --browsers=ChromeDebug",
+    "test-debug-firefox": "ng test --browsers=FirefoxDebug",
     "lint": "ng lint",
     "e2e": "ng e2e"
   },
@@ -39,6 +41,7 @@
     "karma": "~4.1.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage-istanbul-reporter": "~2.0.1",
+    "karma-firefox-launcher": "^1.1.0",
     "karma-jasmine": "~2.0.1",
     "karma-jasmine-html-reporter": "^1.4.0",
     "protractor": "~5.4.0",


### PR DESCRIPTION
…ebug-firefox npm run commands to simplify unit test debugging.  Added -o flag on the start commands.

Note: pulling this change will require a fresh `npm install` to download the karma-firefox-launcher dependency.