### PR TITLE
Feature/demo feedback

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -3948,8 +3948,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3970,14 +3969,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3992,20 +3989,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4122,8 +4116,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4135,7 +4128,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4150,7 +4142,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4158,14 +4149,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4184,7 +4173,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4265,8 +4253,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4278,7 +4265,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4364,8 +4350,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4401,7 +4386,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4421,7 +4405,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4465,14 +4448,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -33,6 +33,7 @@
     "@angular/router": "~8.0.0",
     "@material/button": "^3.1.0",
     "@material/icon-button": "^3.1.0",
+    "@material/ripple": "^3.1.0",
     "angulartics2": "^7.5.2",
     "ng2-tooltip-directive": "2.1.9",
     "rxjs": "~6.4.0",

--- a/webapp/src/app/common/controls/read-more/read-more.component.html
+++ b/webapp/src/app/common/controls/read-more/read-more.component.html
@@ -1,1 +1,1 @@
-{{ displayText }} <a href="javascript:void(0)" (click)="toggleCollapsed()">{{ collapsed ? 'more' : 'less' }}</a>
+{{ displayText }}<a *ngIf="collapsible" href="javascript:void(0)" (click)="toggleCollapsed()">{{ collapsed ? 'more' : 'less' }}</a>

--- a/webapp/src/app/common/controls/read-more/read-more.component.spec.ts
+++ b/webapp/src/app/common/controls/read-more/read-more.component.spec.ts
@@ -1,7 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { ReadMoreComponent } from './read-more.component';
-import { By } from '@angular/platform-browser';
 
 describe('ReadMoreComponent', () => {
   let component: ReadMoreComponent;

--- a/webapp/src/app/common/controls/read-more/read-more.component.spec.ts
+++ b/webapp/src/app/common/controls/read-more/read-more.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ReadMoreComponent } from './read-more.component';
+import { By } from '@angular/platform-browser';
 
 describe('ReadMoreComponent', () => {
   let component: ReadMoreComponent;
@@ -21,5 +22,47 @@ describe('ReadMoreComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should show more link and truncate if more than MaxNumberOfCharacters', ()=> {
+    component.text = `Red hair crookshanks bludger Marauder’s Map Prongs sunshine daisies butter mellow Ludo Bagman. 
+      Beaters gobbledegook N.E.W.T., Honeydukes eriseD inferi Wormtail. Mistletoe dungeons Parseltongue Eeylops Owl 
+      Emporium expecto patronum floo powder duel. Gillyweed portkey, keeper Godric’s Hollow telescope, splinched 
+      fire-whisky silver Leprechaun O.W.L. stroke the spine. Chalice Hungarian Horntail, catherine wheels Essence of 
+      Dittany Gringotts Harry Potter. Prophecies Yaxley green eyes Remembrall horcrux hand of the servant. Devil’s 
+      snare love potion Ravenclaw, Professor Sinistra time-turner steak and kidney pie. Cabbage Daily Prophet letters 
+      from no one Dervish and Banges leg.`;
+
+    fixture.detectChanges();
+
+    const actual = fixture.debugElement.nativeElement;
+    expect(actual.textContent.length).toBeLessThan(component.text.length);
+    expect(actual.querySelector('a').textContent).toContain('more');        
+  });
+
+  it('should show less link and not truncate if more than MaxNumberOfCharacters', ()=> {
+    component.text = `Red hair crookshanks bludger Marauder’s Map Prongs sunshine daisies butter mellow Ludo Bagman. 
+      Beaters gobbledegook N.E.W.T., Honeydukes eriseD inferi Wormtail. Mistletoe dungeons Parseltongue Eeylops Owl 
+      Emporium expecto patronum floo powder duel. Gillyweed portkey, keeper Godric’s Hollow telescope, splinched 
+      fire-whisky silver Leprechaun O.W.L. stroke the spine. Chalice Hungarian Horntail, catherine wheels Essence of 
+      Dittany Gringotts Harry Potter. Prophecies Yaxley green eyes Remembrall horcrux hand of the servant. Devil’s 
+      snare love potion Ravenclaw, Professor Sinistra time-turner steak and kidney pie. Cabbage Daily Prophet letters 
+      from no one Dervish and Banges leg.`;
+
+    component.toggleCollapsed();
+    fixture.detectChanges();
+
+    const actual = fixture.debugElement.nativeElement
+    expect(actual.textContent).toContain(component.text);
+    expect(actual.querySelector('a').textContent).toContain('less');        
+  });
+
+  it('should hide more / less link when given text is less than MaxNumberOfCharacters', ()=> {
+    component.text = `small-text`;
+    fixture.detectChanges();
+
+    const actual = fixture.debugElement.nativeElement
+    expect(actual.textContent).toContain(component.text);
+    expect(actual.querySelector('a')).toBeNull();        
   });
 });

--- a/webapp/src/app/common/controls/read-more/read-more.component.ts
+++ b/webapp/src/app/common/controls/read-more/read-more.component.ts
@@ -1,35 +1,53 @@
 import { Component, OnInit, Input, OnChanges } from '@angular/core';
 
+/**
+ * This component shows a "more" link and truncates the given text if the length is more 
+ * than the MaxNumberOfCharacters.,  When expanded, "more" changes to "less".
+ */
 @Component({
   selector: 'sbdl-read-more',
   templateUrl: './read-more.component.html'
 })
-export class ReadMoreComponent implements OnInit, OnChanges {
+export class ReadMoreComponent implements OnInit {
+  /**
+   * The text to truncate if the length is over the MaxNumberOfCharacters
+   */
   @Input()
-  text: string;
+  set text(value: string) {
+    this._text = value;
+    this.onTextChanges();
+  }
+
+  get text(): string {
+    return this._text;
+  }
 
   readonly MaxNumberOfCharacters = 168;
+
   displayText: string;
-
   collapsed: boolean = true;
+  collapsible: boolean = false;
 
-  @Input()
-  truncated: boolean;
+  private _text: string;
 
   constructor() { }
 
   ngOnInit() {
   }
 
-  ngOnChanges() {
-    this.truncated = this.text && this.text.length > this.MaxNumberOfCharacters;
-    this.displayText = this.text != null && this.collapsed
-      ? this.text.substring(0, this.MaxNumberOfCharacters) + '...'
-      : this.text;
-  }
-
   toggleCollapsed() {
     this.collapsed = !this.collapsed;
-    this.ngOnChanges();
+    this.toggleDisplayText();
+  }
+
+  private onTextChanges() {
+    this.collapsible = this.text && this.text.length > this.MaxNumberOfCharacters;
+    this.toggleDisplayText();
+  }
+
+  private toggleDisplayText() {
+    this.displayText = this.text && this.collapsed && this.collapsible
+      ? this.text.substring(0, this.MaxNumberOfCharacters) + '...'
+      : this.text;
   }
 }

--- a/webapp/src/app/data/mock-data.ts
+++ b/webapp/src/app/data/mock-data.ts
@@ -463,7 +463,7 @@ const polyfillMissingApiData2 = {
 		{ title: 'Central Ideas', shortName: '9' },
 		{ title: 'Use Evidence', shortName: '4' }
 	],
-	learningGoals: 'The student can solve real-world and mathematical one-step problems involving division of fractions by fractions.',
+	learningGoals: 'The student can solve real-world and mathematical one-step problems involving division of fractions by fractions.  The student can solve real-world and mathematical one-step problems involving division of fractions by fractions.',
 	connectionsPlaylist: [ {
 		title: 'Grade 6 Science',
 		numberOfResources: 24,

--- a/webapp/src/app/resource/instructional/attachments/attachments.component.html
+++ b/webapp/src/app/resource/instructional/attachments/attachments.component.html
@@ -3,16 +3,14 @@
       <i class="far fa-paperclip"></i>Attachments
   </h4>
   <p>This resource relies on the following materials. Download them to use.</p>
-  <div *ngFor="let attachment of models" class="attachment-card">
+  <a *ngFor="let attachment of models" [href]="attachment.downloadUrl" [download]="attachment.filename"  class="attachment-card"  #attachments>
     <div class="type-info">
       <span class="attachment-type">{{ attachment.type }}</span>
       <i class="far {{attachment.fileType | fileTypeIcon }}"></i>
     </div>
     <p>{{ attachment.title }}</p>
-    <div>
-      <a [href]="attachment.downloadUrl" [download]="attachment.filename" class="download-link">
+    <div class="download-text">
         Download ({{attachment.fileExtension}} {{ attachment.fileSizeInKB }} KB)
-      </a>
     </div>
-  </div>
+  </a>
 </article>

--- a/webapp/src/app/resource/instructional/attachments/attachments.component.scss
+++ b/webapp/src/app/resource/instructional/attachments/attachments.component.scss
@@ -29,6 +29,7 @@
         margin-bottom: $spacer;
         cursor: pointer;
         display: block;
+        color: $neutral-900;
 
         // keeps the ripple inside the card.
         position: relative;

--- a/webapp/src/app/resource/instructional/attachments/attachments.component.scss
+++ b/webapp/src/app/resource/instructional/attachments/attachments.component.scss
@@ -1,6 +1,7 @@
 @import "spacing";
 @import "fonts";
 @import "colors";
+@import "@material/ripple/mdc-ripple";
 
 :host {
     display: block;
@@ -16,14 +17,22 @@
     position: relative;
 
     .attachment-card  {
+        @include mdc-ripple-surface;
+        @include mdc-ripple-radius-bounded;
+        @include mdc-states;
+
         background-image: url('/assets/images/attachment-card-bg.png');
         background-repeat: no-repeat;
         background-size: auto 100%;
+    
         border-radius: 2px;
         margin-bottom: $spacer;
-        
-        // background-position: left 184px bottom;
-        /* 1dp — Elevation */
+        cursor: pointer;
+        display: block;
+
+        // keeps the ripple inside the card.
+        position: relative;
+        overflow: hidden;
 
         box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.2), 0px 2px 2px rgba(0, 0, 0, 0.12), 0px 0px 2px rgba(0, 0, 0, 0.14);
         padding: $spacer $spacer $spacer $spacer-md;
@@ -41,7 +50,7 @@
                 color: rgba(33, 38, 47, 0.65);;
             }
         }
-        .download-link {
+        .download-text{
             color: rgba($neutral-900, 0.65);
         }
     }

--- a/webapp/src/app/resource/instructional/attachments/attachments.component.scss
+++ b/webapp/src/app/resource/instructional/attachments/attachments.component.scss
@@ -8,6 +8,7 @@
 }
 
 .attachments-container {
+    padding-top: $spacer;
     max-width: var(--measure);
     width: var(--measure);
     margin-right: $spacer-xl;

--- a/webapp/src/app/resource/instructional/attachments/attachments.component.scss
+++ b/webapp/src/app/resource/instructional/attachments/attachments.component.scss
@@ -10,7 +10,6 @@
 .attachments-container {
     padding-top: $spacer;
     max-width: var(--measure);
-    width: var(--measure);
     margin-right: $spacer-xl;
     margin-left: $spacer-lg;
     margin-bottom: $spacer-lg;

--- a/webapp/src/app/resource/instructional/attachments/attachments.component.ts
+++ b/webapp/src/app/resource/instructional/attachments/attachments.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, Input, ViewChild, ElementRef, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, Input, ViewChild, ElementRef, Output, EventEmitter, ViewChildren } from '@angular/core';
+import { MDCRipple } from '@material/ripple/component';
 
 @Component({
   selector: 'sbdl-attachments',
@@ -16,16 +17,25 @@ export class AttachmentsComponent implements OnInit {
   @ViewChild('header', { static: false })
   headerElement: ElementRef;
 
+
+  @ViewChildren('attachments')
+  attachmentElementRefs: ElementRef[];
+
   constructor() { }
 
   ngOnInit() {
   }
-
+  
   ngAfterViewInit(): void {
     if(this.headerElement) {
       this.sectionElementLoaded.emit(this.headerElement.nativeElement);
     } else {
       this.sectionElementLoaded.emit({});
+    }
+
+    // Add ripples
+    for(let attachmentRef of this.attachmentElementRefs) {
+      MDCRipple.attachTo(attachmentRef.nativeElement);
     }
   }
 }

--- a/webapp/src/app/resource/instructional/content/resource-content.component.html
+++ b/webapp/src/app/resource/instructional/content/resource-content.component.html
@@ -37,7 +37,7 @@
     <span class="emphasis-medium">Updated</span>
     {{ details.lastModified | date: 'mediumDate' }}
   </span>
-  <sbdl-button class="primary">
+  <sbdl-button class="primary" (click)="scrollToAttachments()">
     <i class="far fa-paperclip"></i> Attachments
   </sbdl-button>
 </header>

--- a/webapp/src/app/resource/instructional/content/resource-content.component.html
+++ b/webapp/src/app/resource/instructional/content/resource-content.component.html
@@ -1,26 +1,29 @@
-<div class="actions">
-  <sbdl-button-icon (click)="share()"><i class="far fa-share"></i></sbdl-button-icon>
-  <ng-container #shareButton></ng-container>
-  <sbdl-button-icon (click)="toggleFavorite()">
-    <div *ngIf="!togglingFavorite && model.details.favorite">
-      <i class="fas fa-bookmark"></i>
-    </div>
-    <div *ngIf="!togglingFavorite && !model.details.favorite">
-      <i class="far fa-bookmark"></i>
-    </div>
-    <div *ngIf="togglingFavorite">
-      <i class="fas fa-spinner fa-spin"></i>
-    </div>
-  </sbdl-button-icon>
-  <sbdl-button-icon><i class="far fa-print"></i></sbdl-button-icon>
-  <sbdl-button-icon (click)="toggleReadingMode()">
-    <div *ngIf="readingMode">
-      <i class="far fa-compress-alt"></i>
-    </div>
-    <div *ngIf="!readingMode">
-      <i class="far fa-expand-alt"></i>
-    </div>
-  </sbdl-button-icon>
+<div class="top-header">
+  <img src="/assets/images/yellow-spot.png" />
+  <div class="actions">
+    <sbdl-button-icon (click)="share()"><i class="far fa-share"></i></sbdl-button-icon>
+    <ng-container #shareButton></ng-container>
+    <sbdl-button-icon (click)="toggleFavorite()">
+      <div *ngIf="!togglingFavorite && model.details.favorite">
+        <i class="fas fa-bookmark"></i>
+      </div>
+      <div *ngIf="!togglingFavorite && !model.details.favorite">
+        <i class="far fa-bookmark"></i>
+      </div>
+      <div *ngIf="togglingFavorite">
+        <i class="fas fa-spinner fa-spin"></i>
+      </div>
+    </sbdl-button-icon>
+    <sbdl-button-icon><i class="far fa-print"></i></sbdl-button-icon>
+    <sbdl-button-icon (click)="toggleReadingMode()">
+      <div *ngIf="readingMode">
+        <i class="far fa-compress-alt"></i>
+      </div>
+      <div *ngIf="!readingMode">
+        <i class="far fa-expand-alt"></i>
+      </div>
+    </sbdl-button-icon>
+  </div>
 </div>
 <header>
   <h1 #getStarted>{{ details.title }}</h1>
@@ -39,11 +42,14 @@
   </sbdl-button>
 </header>
 <sbdl-overview [model]="model.overview"  (sectionElementLoaded)="setGetStarted($event)"></sbdl-overview>
+<hr *ngIf="model.steps.length > 0"/>
 <sbdl-step-by-step [models]="model.steps" (sectionElementLoaded)="setSteps($event)"></sbdl-step-by-step>
+<hr *ngIf="model.attachments.length > 0"/>
 <sbdl-attachments [models]="model.attachments" (sectionElementLoaded)="setAttachments($event)"></sbdl-attachments>
+<hr/>
 <sbdl-differentiation [model]="model.differentiation" (sectionElementLoaded)="setDifferentiation($event)"></sbdl-differentiation>
+<hr/>
 <sbdl-formative [model]="model.formative" (sectionElementLoaded)="setFormative($event)"></sbdl-formative>
-
 <ng-template #sharePopover>
   <div class="share-popover">
       <h6>Share this resource</h6>

--- a/webapp/src/app/resource/instructional/content/resource-content.component.scss
+++ b/webapp/src/app/resource/instructional/content/resource-content.component.scss
@@ -6,20 +6,12 @@
     position: relative;
     display: flex;
     flex-direction: column;
-    align-items: center;
     max-width: none;
-    &::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: calc(50% - 32.4ch - 42px);
-        display: block;
-        width: 100px;
-        height: 46px;
-        background-image: url('./../../../../assets/images/yellow-spot.png');
-        background-position: top left;
-        background-size: cover;
-        background-repeat: no-repeat;
+    .top-header {
+        display: flex;
+        justify-content: space-between;
+        width: 100%;
+        align-items: baseline;
     }
     .actions {
         align-self: flex-end;
@@ -64,6 +56,19 @@
     .modified-info {
         font-size: 0.8em;
         font-style: italic;
+    }
+
+    hr {
+        width:100%;
+        height: 1px;
+        color: $neutral-900;
+        background-color: $neutral-900;
+        border:none;
+
+        padding-left: 5rem;
+        opacity: 0.2;
+        transform: translateX(-1.5rem);
+        margin-bottom: 51px;
     }
 }
 

--- a/webapp/src/app/resource/instructional/content/resource-content.component.ts
+++ b/webapp/src/app/resource/instructional/content/resource-content.component.ts
@@ -89,6 +89,12 @@ export class ResourceContentComponent implements OnInit {
     this.popoverService.open(this.shareContainer, this.sharePopover);
   }
 
+  scrollToAttachments() {
+    if(this.scrollableElements && this.scrollableElements.attachments) {
+      this.scrollableElements.attachments.scrollIntoView({behavior: 'smooth', block: 'start', inline: 'nearest'});
+    }
+  }
+
   copyToClipboard(inputElement) {
     inputElement.select();
     document.execCommand('copy');

--- a/webapp/src/app/resource/instructional/differentiation/differentiation.component.scss
+++ b/webapp/src/app/resource/instructional/differentiation/differentiation.component.scss
@@ -8,6 +8,7 @@
 }
 
 .differentiation-container {
+    padding-top: $spacer;
     max-width: var(--measure);
     width: var(--measure);
     margin-right: $spacer-xl;

--- a/webapp/src/app/resource/instructional/differentiation/differentiation.component.scss
+++ b/webapp/src/app/resource/instructional/differentiation/differentiation.component.scss
@@ -10,7 +10,6 @@
 .differentiation-container {
     padding-top: $spacer;
     max-width: var(--measure);
-    width: var(--measure);
     margin-right: $spacer-xl;
     margin-left: $spacer-lg;
     margin-bottom: $spacer-lg;

--- a/webapp/src/app/resource/instructional/formative/formative.component.scss
+++ b/webapp/src/app/resource/instructional/formative/formative.component.scss
@@ -10,7 +10,6 @@
 .formative-container {
     padding-top: $spacer;
     max-width: var(--measure);
-    width: var(--measure);
     margin-right: $spacer-xl;
     margin-left: $spacer-lg;
     margin-bottom: $spacer-lg;

--- a/webapp/src/app/resource/instructional/formative/formative.component.scss
+++ b/webapp/src/app/resource/instructional/formative/formative.component.scss
@@ -8,6 +8,7 @@
 }
 
 .formative-container {
+    padding-top: $spacer;
     max-width: var(--measure);
     width: var(--measure);
     margin-right: $spacer-xl;

--- a/webapp/src/app/resource/instructional/instructional-resource.component.scss
+++ b/webapp/src/app/resource/instructional/instructional-resource.component.scss
@@ -83,7 +83,7 @@
         &.highlighted::before {
             content: '';
             position: absolute;
-            top: -$spacer;
+            top: 0;
             bottom: -$spacer;
             left: -3.5rem;
             right: -$spacer-xl;

--- a/webapp/src/app/resource/instructional/instructional-resource.component.scss
+++ b/webapp/src/app/resource/instructional/instructional-resource.component.scss
@@ -36,7 +36,6 @@
 
     .resource-content {
         padding: 0 $spacer-lg;
-        flex-grow:1;
         max-width: none;
     }
     .metadata {

--- a/webapp/src/app/resource/instructional/overview/overview.component.html
+++ b/webapp/src/app/resource/instructional/overview/overview.component.html
@@ -15,7 +15,9 @@
   </div>
   <div>
     <h5>Learning Goal</h5>
-    <p>{{ model.learningGoal }}</p>
+    <p>
+      <sbdl-read-more [text] = "model.learningGoal"></sbdl-read-more>
+    </p>
   </div>
   <div>
     <h5>Success Criteria</h5>

--- a/webapp/src/app/resource/instructional/overview/overview.component.scss
+++ b/webapp/src/app/resource/instructional/overview/overview.component.scss
@@ -6,6 +6,7 @@
 }
 
 .overview-container {
+    padding-top: $spacer;
     max-width: var(--measure);
     width: var(--measure);
     margin-right: $spacer-xl;

--- a/webapp/src/app/resource/instructional/overview/overview.component.scss
+++ b/webapp/src/app/resource/instructional/overview/overview.component.scss
@@ -8,7 +8,6 @@
 .overview-container {
     padding-top: $spacer;
     max-width: var(--measure);
-    width: var(--measure);
     margin-right: $spacer-xl;
     margin-left: $spacer-lg;
     margin-bottom: $spacer-lg;

--- a/webapp/src/app/resource/instructional/step-by-step/step-by-step.component.scss
+++ b/webapp/src/app/resource/instructional/step-by-step/step-by-step.component.scss
@@ -9,7 +9,6 @@
 .step-container {
     padding-top: $spacer;
     max-width: var(--measure);
-    width: var(--measure);
     margin-right: $spacer-xl;
     margin-left: $spacer-lg;
     margin-bottom: $spacer-lg;

--- a/webapp/src/app/resource/instructional/step-by-step/step-by-step.component.scss
+++ b/webapp/src/app/resource/instructional/step-by-step/step-by-step.component.scss
@@ -7,6 +7,7 @@
 }
 
 .step-container {
+    padding-top: $spacer;
     max-width: var(--measure);
     width: var(--measure);
     margin-right: $spacer-xl;
@@ -24,7 +25,7 @@
 
         li {
             position: relative; // required to keep the highlighted class only around this li.
-            margin-bottom: $spacer-lg;
+            padding-top: $spacer;
         }
     }
 

--- a/webapp/src/app/resource/outline/outline.component.html
+++ b/webapp/src/app/resource/outline/outline.component.html
@@ -13,8 +13,10 @@
     </sbdl-button>
   </li>
   <li *ngIf="model.steps.length > 0" class="steps">
-    <sbdl-icon icon="steps"></sbdl-icon>
-    Step-by-Step
+    <div class="steps-header">
+      <sbdl-icon icon="steps"></sbdl-icon>
+      Step-by-Step
+    </div>
     <ol>
       <li *ngFor="let step of model.steps; let i = index" >
         <sbdl-button class="step" (click)="scrollToElement(scrollableElements.steps[i])" (blur)="removeClass(scrollableElements.steps[i])">{{ step.title }}</sbdl-button>

--- a/webapp/src/app/resource/outline/outline.component.scss
+++ b/webapp/src/app/resource/outline/outline.component.scss
@@ -2,7 +2,7 @@
 @import 'typography';
 
 :host {
-    margin-top: 4rem;
+    padding-top: 4rem;
 
     h6 {
         font-family: $font-family-title;
@@ -25,6 +25,7 @@
         font-size: 1rem;
         color: $neutral-900;
     }
+
     ul > li {
         border-top: 1px solid $neutral-100;
         width: 100%;
@@ -33,14 +34,14 @@
             white-space: pre;
         }
         padding: 8px 0 8px 8px;
-        &.steps {
-            padding: 1rem;
-        }
-
         sbdl-icon, svg {
             color: rgba($neutral-900, 0.65);
             padding-right: 8px;
         };
+    }
+
+    .steps-header {
+        padding: 0.5rem;
     }
     ul > li:first-child {
         border-top: none;
@@ -48,9 +49,7 @@
 
     ol {
         list-style-type: none;
-        margin-left: 0;
-        padding-left: 8px;
-        padding-top: 17px;
+        padding-left: 13px;
     }
 
     ol > li:before {

--- a/webapp/src/app/resource/outline/outline.component.ts
+++ b/webapp/src/app/resource/outline/outline.component.ts
@@ -23,7 +23,7 @@ export class OutlineComponent implements OnInit {
   }
 
   scrollToElement(element: Element): void {
-    element.scrollIntoView({behavior: "smooth", block: "start", inline: "nearest"});
+    element.scrollIntoView({behavior: 'smooth', block: 'start', inline: 'nearest'});
     element.classList.add('highlighted');
   }
 

--- a/webapp/src/ui-kit/_buttons.scss
+++ b/webapp/src/ui-kit/_buttons.scss
@@ -36,9 +36,9 @@
 
 .step > .mdc-button:not(:disabled) {
     color: $neutral-900;
-    width: calc(100% + 17px);
-    margin-left: -12px;
-    padding-left: 31px;
+    width: calc(100% + 15px);
+    margin-left: -15px;
+    padding-left: 36px;
     padding-right: 28px;
 
     // ellipsis for overflow
@@ -61,6 +61,7 @@
 
 .step > .mdc-button:not(:disabled):focus {
     border-left: $action-500 solid 4px;
+    margin-left: -19px;
 }
 
 .step > .mdc-button:before,

--- a/webapp/src/ui-kit/_buttons.scss
+++ b/webapp/src/ui-kit/_buttons.scss
@@ -68,5 +68,5 @@
 .step > .mdc-button:after,
 .outline >.mdc-button:before,
 .outline > .mdc-button:after {
-  background-color: $action-300;
+  background-color: $action-500;
 }


### PR DESCRIPTION
This PR addresses various minor aesthetics discussed during the demo.
  - Additional padding when an element is scrolled to
  - Added read-more control to learning goal should it go over
  - Fixed an issue with tabbing the outline when in reading mode would throw off margins /padding
  - Attachment card is now clickable and has the mdc ripple
  - Attachments button at in the content section now works