### PR TITLE
Feature/ui tweaks

### DIFF
--- a/webapp/src/app/common/controls/tooltip/tooltip.component.scss
+++ b/webapp/src/app/common/controls/tooltip/tooltip.component.scss
@@ -6,6 +6,20 @@
     color: $info-500;
 }
 
+::ng-deep {
+    .gradient-hover:hover {
+        text-shadow:
+            -1px -1px 0 #fff,  
+            1px -1px 0 #fff,
+            -1px 1px 0 #fff,
+            1px 1px 0 #fff;
+        background-image: linear-gradient(90deg, #FFC73A 0%, #BA2CA3 99.19%);
+        background-position: left bottom;
+        background-size: 100% 2px;
+        background-repeat: no-repeat;
+    }
+}
+
 .close-button {
     display:flex;
     justify-content: flex-end;

--- a/webapp/src/app/data/mock-data.ts
+++ b/webapp/src/app/data/mock-data.ts
@@ -78,6 +78,7 @@ export const mockApiResourceExample = {
 	pii: "None",
 	subject: ["ELA", "Math"],
 	grade: ["Grade 6", "Grade 8", "Grade 9"],
+	
 	alignmentTags: "",
 	educationAlignments: [
 		{ title: "", shortName: "" },
@@ -118,6 +119,7 @@ const polyfillMissingApiData = {
 
 	// metadata
 	resourceThumbnail: mockResourceImage,
+	grades: [6, 8, 9],
 	educationalAlignments: [
 		{ title: 'Problem Solving', shortName: '2'}
 	], 
@@ -398,6 +400,7 @@ export const mockApiResourceWithNulls = {
 	steps: undefined,
 	subject: undefined,
 	grade: undefined,
+	grades: undefined,
 	targetAlignments: undefined,
 	educationalAlignments: undefined,
 	standards: undefined,
@@ -488,6 +491,7 @@ const polyfillMissingApiData2 = {
 		{ title: 'Central Ideas', shortName: '9' },
 		{ title: 'Use Evidence', shortName: '4' }
 	],
+	grades: [6],
 	learningGoals: 'The student can solve real-world and mathematical one-step problems involving division of fractions by fractions.  The student can solve real-world and mathematical one-step problems involving division of fractions by fractions.',
 	connectionsPlaylist: [ {
 		title: 'Grade 6 Science',

--- a/webapp/src/app/data/mock-data.ts
+++ b/webapp/src/app/data/mock-data.ts
@@ -128,6 +128,7 @@ const polyfillMissingApiData = {
 	connectionsPlaylist: [ {
 		title: 'Grade 6 Fractions',
 		numberOfResources: 6,
+		resourceId: 8,
 		assessmentType: 1 // how will this be defined?
 	}],
 	standards: ['6.NS.A.1', '6.NS.A.3', '5.NS.A.4'],
@@ -491,10 +492,12 @@ const polyfillMissingApiData2 = {
 	connectionsPlaylist: [ {
 		title: 'Grade 6 Science',
 		numberOfResources: 24,
+		resourceId: 28,
 		assessmentType: 1 // how will this be defined?
 	}, {
 		title: 'Citing Sources',
 		numberOfResources: 18,
+		resourceId: 29,
 		assessmentType: 1 // how will this be defined?
 	}],
 	standards: ['CCSS.ELA-Literacy.RST.6-8.1', 'CCSS.ELA-Literacy.RST.6-8.2'],

--- a/webapp/src/app/data/resource/embed-strategy-links.service.spec.ts
+++ b/webapp/src/app/data/resource/embed-strategy-links.service.spec.ts
@@ -23,7 +23,7 @@ describe('EmbedStrategLinksService', () => {
       formative: { }
     });
 
-    expect(actual).toBe('<div>Test this is a <sbdl-tooltip title="Accessibility Strategy" text="test description" readMoreUrl="google.com" style="white-space:nowrap;"><i class="far fa-universal-access"></i> Walk the Line</sbdl-tooltip> test.</div>');
+    expect(actual).toBe('<div>Test this is a <sbdl-tooltip title="Accessibility Strategy" text="test description" readMoreUrl="google.com" style="white-space:nowrap;"><i class="far fa-universal-access"></i> <span class="gradient-hover">Walk the Line</span></sbdl-tooltip> test.</div>');
   });
 
   it('should embed formative strategy links', () => {
@@ -37,6 +37,6 @@ describe('EmbedStrategLinksService', () => {
       }] }
     });
 
-    expect(actual).toBe(`<div>Test this is a <sbdl-tooltip title="Formative Assessment Strategy" text="test collab discussion" readMoreUrl="collab.org" style="white-space:nowrap;"><sbdl-icon icon="strategies"></sbdl-icon> Collaborative Discussion</sbdl-tooltip> test.</div>`);
+    expect(actual).toBe(`<div>Test this is a <sbdl-tooltip title="Formative Assessment Strategy" text="test collab discussion" readMoreUrl="collab.org" style="white-space:nowrap;"><sbdl-icon icon="strategies"></sbdl-icon> <span class="gradient-hover">Collaborative Discussion</span></sbdl-tooltip> test.</div>`);
   });
 });

--- a/webapp/src/app/data/resource/embed-strategy-links.service.ts
+++ b/webapp/src/app/data/resource/embed-strategy-links.service.ts
@@ -26,7 +26,7 @@ export class EmbedStrategyLinksService {
 
     for(let strategy of strategies) {
       content = content.replace(strategy.title, 
-        `<sbdl-tooltip title="Accessibility Strategy" text="${strategy.description}" readMoreUrl="${strategy.moreAboutUrl}" style="white-space:nowrap;"><i class="far fa-universal-access"></i> ${strategy.title}</sbdl-tooltip>`
+        `<sbdl-tooltip title="Accessibility Strategy" text="${strategy.description}" readMoreUrl="${strategy.moreAboutUrl}" style="white-space:nowrap;"><i class="far fa-universal-access"></i> <span class="gradient-hover">${strategy.title}</span></sbdl-tooltip>`
       );
     }
     return content;
@@ -39,7 +39,7 @@ export class EmbedStrategyLinksService {
 
     for(let strategy of strategies) {
       content = content.replace(strategy.title, 
-        `<sbdl-tooltip title="Formative Assessment Strategy" text="${strategy.description}" readMoreUrl="${strategy.moreAboutUrl}" style="white-space:nowrap;"><sbdl-icon icon="strategies"></sbdl-icon> ${strategy.title}</sbdl-tooltip>`
+        `<sbdl-tooltip title="Formative Assessment Strategy" text="${strategy.description}" readMoreUrl="${strategy.moreAboutUrl}" style="white-space:nowrap;"><sbdl-icon icon="strategies"></sbdl-icon> <span class="gradient-hover">${strategy.title}</span></sbdl-tooltip>`
       );
     }
     return content;

--- a/webapp/src/app/data/resource/model/resource-details.model.ts
+++ b/webapp/src/app/data/resource/model/resource-details.model.ts
@@ -52,6 +52,7 @@ export interface Alignment {
 
 export interface Playlist {
     title: string;
+    resourceId: number;
     assessmentType: number;
     assessmentTypeIcon: string;
     numberOfResources: number;

--- a/webapp/src/app/data/resource/model/resource-details.model.ts
+++ b/webapp/src/app/data/resource/model/resource-details.model.ts
@@ -7,7 +7,7 @@ export interface ResourceDetailsModel {
     subjects: string[];
 
     // /api/v1/resource.grades
-    grades: string[];
+    grades: number[];
 
     // /api/v1/resource.resourceThumbnailImage
     // as a base-64 encoded string.

--- a/webapp/src/app/data/resource/resource.service.spec.ts
+++ b/webapp/src/app/data/resource/resource.service.spec.ts
@@ -22,7 +22,7 @@ describe('ResourceService', () => {
       expect(resource.resourceId).toBe(1);
       expect(actual.title).toBe('Connecting Fraction Division Equations to Visual Models');
       expect(actual.subjects).toEqual(['ELA', 'Math']);
-      expect(actual.grades).toEqual(['Grade 6', 'Grade 8', 'Grade 9']);
+      expect(actual.grades).toEqual([6,8,9]);
       expect(actual.image).toBeDefined();
       expect(actual.author).toBe('Mary Smith');
       expect(actual.authorOrganization).toBe('John Roberts');

--- a/webapp/src/app/data/resource/resource.service.ts
+++ b/webapp/src/app/data/resource/resource.service.ts
@@ -106,7 +106,7 @@ export class ResourceService {
       title: apiResource.title,
       favorite: apiResource.favorite,
       subjects: coalesce(apiResource.subject, []),
-      grades: coalesce(apiResource.grade, []),
+      grades: coalesce(apiResource.grades, []),
       image: apiResource.resourceThumbnail,
       author: apiResource.author,
       authorOrganization: apiResource.publisher,

--- a/webapp/src/app/data/resource/resource.service.ts
+++ b/webapp/src/app/data/resource/resource.service.ts
@@ -124,6 +124,7 @@ export class ResourceService {
 
       relatedPlaylists: coalesce(apiResource.connectionsPlaylist, []).map(p => <Playlist>{
         title: p.title,
+        resourceId: p.resourceId,
         numberOfResources: p.numberOfResources,
         assessmentType: p.assessmentType,
         assessmentTypeIcon: this.assessmentTypeToIconMap.get(p.assessmentType)

--- a/webapp/src/app/pipes/join.pipe.spec.ts
+++ b/webapp/src/app/pipes/join.pipe.spec.ts
@@ -23,4 +23,22 @@ describe('Join.PipePipe', () => {
     const actual = pipe.transform([{ name: 'Apple' },{ name: 'Banana' },{ name: 'Carrots' }], { field: 'name' });
     expect(actual).toBe('Apple, Banana, Carrots');
   });
+
+  it('should join arrays with a conjunction', ()=> {
+    const pipe = new JoinPipe();
+    const actual = pipe.transform(['Apple', 'Banana', 'Carrots'], { conjunction: 'and' });
+    expect(actual).toBe('Apple, Banana, and Carrots');
+  });
+
+  it('should join array and use conjuction instead of separator for count of 2', ()=> {
+    const pipe = new JoinPipe();
+    const actual = pipe.transform(['Apple', 'Carrots'], { conjunction: 'and' });
+    expect(actual).toBe('Apple and Carrots');
+  });
+
+  it('should join array and not use conjuction for count of 1', ()=> {
+    const pipe = new JoinPipe();
+    const actual = pipe.transform(['Apple'], { conjunction: 'and' });
+    expect(actual).toBe('Apple');
+  });
 });

--- a/webapp/src/app/pipes/join.pipe.ts
+++ b/webapp/src/app/pipes/join.pipe.ts
@@ -10,7 +10,17 @@ export class JoinPipe implements PipeTransform {
 
     const array = args && args.field ? value.map(x => x[args.field]) :  value;
     const separator = args && args.separator ? args.separator : ', ';
+    const conjunction = args && args.conjunction ? args.conjunction : undefined;
 
-    return array.join(separator);
+    const joinedString = array.join(separator);
+
+    if(!conjunction)
+      return joinedString;
+
+    const lastIndex = joinedString.lastIndexOf(separator);
+    return joinedString.slice(0, lastIndex) 
+      + joinedString
+        .slice(lastIndex)
+        .replace(separator, (array.length > 2 ? separator : ' ') + conjunction + ' ');
   }
 }

--- a/webapp/src/app/resource/components/formative/formative.component.html
+++ b/webapp/src/app/resource/components/formative/formative.component.html
@@ -23,7 +23,7 @@
   </p>
   <section>
     <h5 *ngIf="!showProfLearningContent">Strategies Used</h5>
-    <div *ngFor="let strategy of model.strategies">
+    <div *ngFor="let strategy of model.strategies" class="strategy-link">
       <h6><a [href]="strategy.moreAboutUrl" target="_blank">{{ strategy.title }} <i class="far fa-arrow-right"></i></a></h6>
       <p>{{ strategy.description }}</p>
     </div>

--- a/webapp/src/app/resource/components/formative/formative.component.scss
+++ b/webapp/src/app/resource/components/formative/formative.component.scss
@@ -16,7 +16,7 @@
     position: relative;
 
     .leading-icon {
-        text-indent: calc((-1) * (var(--icon-width) + var(--icon-margin) + 10px));
+        margin-left:-16px;
         sbdl-icon {
             color: $brand-green;
             background: url('/assets/images/green-spot-3.png') no-repeat;
@@ -49,5 +49,14 @@
 
     .prof-learning-content {
         margin-bottom: $spacer-lg;
+    }
+
+    .strategy-link {
+        p {
+            margin-top: 0;
+        }
+        h6 {
+            margin-bottom: 3px;
+        }
     }
 }

--- a/webapp/src/app/resource/components/formative/formative.component.scss
+++ b/webapp/src/app/resource/components/formative/formative.component.scss
@@ -42,6 +42,7 @@
 
             a:hover {
                 text-decoration: underline;
+                color: $info-500;
             }
 
             .fa-arrow-right {

--- a/webapp/src/app/resource/components/formative/formative.component.scss
+++ b/webapp/src/app/resource/components/formative/formative.component.scss
@@ -30,33 +30,36 @@
         margin-bottom: $spacer;
     }
 
-    h6 {
-        a,
-        a:link,
-        a:visited,
-        a:hover,
-        a:active {
-            color: $neutral-900;
-            text-decoration: none;
-            font-weight: normal;
-        }
-    }
+    .strategy-link {
+        h6 {
+            a,
+            a:link,
+            a:visited,
+            a:active {
+                color: $neutral-900;
+                font-weight: normal;
+            }
 
-    .fa-arrow-right {
-        color: $info-500;
-        padding-left: $spacer-sm;
+            a:hover {
+                text-decoration: underline;
+            }
+
+            .fa-arrow-right {
+                color: $info-500;
+                padding-left: $spacer-sm;
+            }
+
+            margin-bottom: 3px;
+        }
+
+        p {
+            margin-top: 0;
+        }
     }
 
     .prof-learning-content {
         margin-bottom: $spacer-lg;
     }
 
-    .strategy-link {
-        p {
-            margin-top: 0;
-        }
-        h6 {
-            margin-bottom: 3px;
-        }
-    }
+
 }

--- a/webapp/src/app/resource/components/metadata/metadata.component.scss
+++ b/webapp/src/app/resource/components/metadata/metadata.component.scss
@@ -12,7 +12,6 @@ h5 {
 :host {
     padding-left: 20px;
     z-index: inherit;
-    // position: relative;
 }
 
 .image-thumbnail {

--- a/webapp/src/app/resource/components/outline/outline.component.scss
+++ b/webapp/src/app/resource/components/outline/outline.component.scss
@@ -46,6 +46,7 @@
 
     .steps-header {
         padding: 0.5rem;
+        font-weight: 400;
     }
     ul > li:first-child {
         border-top: none;
@@ -74,6 +75,5 @@
         counter-increment: customlistcounter;
         display:block;
         font-size: 0.9rem;
-        font-weight: 300;
     }
 }

--- a/webapp/src/app/resource/components/section/section.component.scss
+++ b/webapp/src/app/resource/components/section/section.component.scss
@@ -16,7 +16,7 @@
     position: relative;
 
     .leading-icon.yellow {
-        margin-left: -11px;
+        margin-left: -16px;
         sbdl-icon, svg {
             color: $warning-900;
             background: url('/assets/images/yellow-spot-4.png') no-repeat;
@@ -28,7 +28,7 @@
     }
 
     .leading-icon.blue {
-        text-indent: calc((-1) * (var(--icon-width) + var(--icon-margin) + 9px));
+        margin-left: -16px;
         sbdl-icon, svg {
             color: $brand-blue;
             background: url('/assets/images/blue-spot.png') no-repeat;
@@ -39,7 +39,8 @@
     }
 
     .leading-icon.green {
-        text-indent: calc((-1) * (var(--icon-width) + var(--icon-margin) + 10px));
+        margin-left: -16px;
+        // text-indent: calc((-1) * (var(--icon-width) + var(--icon-margin) + 10px));
         sbdl-icon, svg {
             color: $success-900;
             background: url('/assets/images/green-spot-3.png') no-repeat;

--- a/webapp/src/app/resource/instructional/content/instructional-content.component.html
+++ b/webapp/src/app/resource/instructional/content/instructional-content.component.html
@@ -1,5 +1,5 @@
 <div class="top-header">
-  <img src="/assets/images/yellow-spot.png" />
+  <img src="/assets/images/yellow-spot.png" alt="" />
   <sbdl-actions [model]= "model" (readingModeChanged)="emitReadingModeChanged($event)"></sbdl-actions>
 </div>
 <sbdl-header [model]="model" (attachmentsClicked)="scrollToAttachments()"></sbdl-header>

--- a/webapp/src/app/resource/instructional/differentiation/differentiation.component.html
+++ b/webapp/src/app/resource/instructional/differentiation/differentiation.component.html
@@ -6,7 +6,7 @@
   </section>
   <section>
     <h5>Accessibility Strategies Used</h5>
-    <div *ngFor="let strategy of model.accessibilityStrategies">
+    <div *ngFor="let strategy of model.accessibilityStrategies" class="strategy-link">
       <h6><a [href]="strategy.moreAboutUrl" target="_blank">{{ strategy.title }} <i class="far fa-arrow-right"></i></a></h6>
       <p>{{ strategy.description }}</p>
     </div>

--- a/webapp/src/app/resource/instructional/differentiation/differentiation.component.scss
+++ b/webapp/src/app/resource/instructional/differentiation/differentiation.component.scss
@@ -27,6 +27,7 @@
 
             a:hover {
                 text-decoration: underline;
+                color: $info-500;
             }
 
             .fa-arrow-right {

--- a/webapp/src/app/resource/instructional/differentiation/differentiation.component.scss
+++ b/webapp/src/app/resource/instructional/differentiation/differentiation.component.scss
@@ -28,14 +28,14 @@
     }
 
     .leading-icon{
-        margin-left: -19px;
+        margin-left: -16px;
         svg {
             color: $warning-900;
             background: url('/assets/images/yellow-spot-3.png') no-repeat;
             background-size: contain;
             padding: 7px;
             margin-bottom: -7px;
-            font-size: 2rem;
+            font-size: 1.75rem;
         }
     }
 

--- a/webapp/src/app/resource/instructional/differentiation/differentiation.component.scss
+++ b/webapp/src/app/resource/instructional/differentiation/differentiation.component.scss
@@ -15,15 +15,30 @@
     margin-bottom: $spacer-lg;
     position: relative;
 
-    h6 {
-        a,
-        a:link,
-        a:visited,
-        a:hover,
-        a:active {
-            color: $neutral-900;
-            text-decoration: none;
-            font-weight: normal;
+    .strategy-link {
+        h6 {
+            a,
+            a:link,
+            a:visited,
+            a:active {
+                color: $neutral-900;
+                font-weight: normal;
+            }
+
+            a:hover {
+                text-decoration: underline;
+            }
+
+            .fa-arrow-right {
+                color: $info-500;
+                padding-left: $spacer-sm;
+            }
+
+            margin-bottom: 3px;
+        }
+
+        p {
+            margin-top: 0;
         }
     }
 
@@ -37,10 +52,5 @@
             margin-bottom: -7px;
             font-size: 1.75rem;
         }
-    }
-
-    .fa-arrow-right {
-        color: $info-500;
-        padding-left: $spacer-sm;
     }
 }

--- a/webapp/src/app/resource/instructional/metadata/instructional-metadata.component.html
+++ b/webapp/src/app/resource/instructional/metadata/instructional-metadata.component.html
@@ -17,17 +17,17 @@
 <div class="playlists">
   <h6>Playlists</h6>
   <span class="caption emphasis-medium">Connections playlists utilizing this resource.</span>
-  <div *ngFor="let playlist of model.relatedPlaylists" class="playlist-card">
-      <sbdl-icon [icon]="playlist.assessmentTypeIcon" class="assessment-type-icon"></sbdl-icon>
-      <div class="playlist-title">
-        <div class="title">{{ playlist.title }}</div>
-        <div class="resources" [ngPlural]="playlist.numberOfResources" >
-          <ng-template ngPluralCase="=1">{{ playlist.numberOfResources }} resource</ng-template>
-          <ng-template ngPluralCase="other">{{ playlist.numberOfResources }} resources</ng-template>
-        </div>
+  <a #playlistRef [routerLink]="['/resource', playlist.resourceId ]" *ngFor="let playlist of model.relatedPlaylists" class="playlist-card">
+    <sbdl-icon [icon]="playlist.assessmentTypeIcon" class="assessment-type-icon"></sbdl-icon>
+    <div class="playlist-title">
+      <div class="title">{{ playlist.title }}</div>
+      <div class="resources" [ngPlural]="playlist.numberOfResources" >
+        <ng-template ngPluralCase="=1">{{ playlist.numberOfResources }} resource</ng-template>
+        <ng-template ngPluralCase="other">{{ playlist.numberOfResources }} resources</ng-template>
       </div>
-      <sbdl-icon icon="playlist-play" class="playlist-icon"></sbdl-icon>
-  </div>
+    </div>
+    <sbdl-icon icon="playlist-play" class="playlist-icon"></sbdl-icon>
+  </a>
 </div>
 <ng-template #alignment let-alignments="models" let-title="title" let-titles="titles">
   <label *ngIf="alignments && alignments.length > 0" [ngPlural]="alignments.length">

--- a/webapp/src/app/resource/instructional/metadata/instructional-metadata.component.html
+++ b/webapp/src/app/resource/instructional/metadata/instructional-metadata.component.html
@@ -6,7 +6,13 @@
   <img src="/assets/images/math-2-problem-solving.png">
   <div>
     <h5 class="subjects">{{ model.subjects | join }}</h5>
-    <h6 class="grades">{{ model.grades | join }}</h6>
+    <h6 class="grades">
+        <span [ngPlural]="model.grades.length" >
+          <ng-template ngPluralCase="=1">Grade</ng-template>
+          <ng-template ngPluralCase="other">Grades</ng-template>
+        </span>
+      {{ model.grades | join:{conjunction:'and'} }}
+    </h6>
   </div>
 </div>
 <div class="details">

--- a/webapp/src/app/resource/instructional/metadata/instructional-metadata.component.scss
+++ b/webapp/src/app/resource/instructional/metadata/instructional-metadata.component.scss
@@ -1,6 +1,7 @@
 @import "colors";
 @import "typography";
 @import "spacing";
+@import "@material/ripple/mdc-ripple";
 
 h5,h6 {
     margin-bottom: 0; 
@@ -88,8 +89,13 @@ h5,h6 {
         color: rgba($neutral-900, 0.65);
     }
     .playlist-card {
+        @include mdc-ripple-surface;
+        @include mdc-ripple-radius-bounded;
+        @include mdc-states;
+
         padding: 0.5rem 1rem;
         margin: 1rem 1rem 1rem 0;
+
         position: relative;
         border-radius: 4px;
         box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.2), 0px 2px 2px rgba(0, 0, 0, 0.12), 0px 0px 2px rgba(0, 0, 0, 0.14);
@@ -97,24 +103,27 @@ h5,h6 {
         background-repeat: no-repeat;
         background-size: auto 100%;
         background-color: $white;
+        overflow: hidden;
         display: flex;
-        &:before {
-            content: '';
-            mix-blend-mode: multiply;
-            background-color: $brand-green;
-            display: block;
-            position: absolute;
-            width: 8px;
-            top: 0;
-            bottom: 0;
-            left: 0;
-            opacity: 0.2;
-        }
+        color: $neutral-900;
+
         .assessment-type-icon {
             color: $white;
             font-size: 3rem;
             margin-top: -0.125rem;
             margin-bottom: 1rem;
+            &:before {
+                content: '';
+                mix-blend-mode: multiply;
+                background-color: $brand-green;
+                display: block;
+                position: absolute;
+                width: 8px;
+                top: 0;
+                bottom: 0;
+                left: 0;
+                opacity: 0.2;
+            }
         }
         .playlist-title {
             margin-left: 30px;

--- a/webapp/src/app/resource/instructional/metadata/instructional-metadata.component.ts
+++ b/webapp/src/app/resource/instructional/metadata/instructional-metadata.component.ts
@@ -1,18 +1,29 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, ViewChildren, ElementRef, AfterViewChecked, AfterViewInit } from '@angular/core';
 import { ResourceDetailsModel } from 'src/app/data/resource/model/resource-details.model';
+import { MDCRipple } from '@material/ripple';
 
 @Component({
   selector: 'sbdl-instructional-metadata',
   templateUrl: './instructional-metadata.component.html',
   styleUrls: ['./instructional-metadata.component.scss']
 })
-export class InstructionalMetadataComponent implements OnInit {
+export class InstructionalMetadataComponent implements OnInit, AfterViewInit {
 
   @Input()
   model: ResourceDetailsModel;
 
+  @ViewChildren('playlistRef')
+  playlists: ElementRef[];
+
   constructor() { }
 
   ngOnInit() {
+  }
+
+  ngAfterViewInit(): void {
+    // Add ripples
+    for(let playlist of this.playlists) {
+      MDCRipple.attachTo(playlist.nativeElement);
+    }
   }
 }

--- a/webapp/src/app/resource/professional/content/professional-content.component.html
+++ b/webapp/src/app/resource/professional/content/professional-content.component.html
@@ -1,5 +1,5 @@
 <div class="top-header">
-  <img src="/assets/images/yellow-spot.png" />
+  <img src="/assets/images/yellow-spot.png" alt="" />
   <sbdl-actions [model]= "model" (readingModeChanged)="emitReadingModeChanged($event)"></sbdl-actions>
 </div>
 <sbdl-header [model]="model" (attachmentsClicked)="scrollToAttachments()"></sbdl-header>

--- a/webapp/src/app/resource/resource.component.scss
+++ b/webapp/src/app/resource/resource.component.scss
@@ -101,6 +101,18 @@
             border-width: 0 0 0 4px;
             border-style: solid;
         }
+        &article:not(.highlighted):not(.step-container)::before {
+            content: '';
+            position: absolute;
+            top: 4rem;
+            bottom: 0;
+            left: -2.05rem;
+            display: block;
+            border-color: $neutral-75;
+            border-radius: 0.25rem;
+            border-width: 0 0 0 2px;
+            border-style: solid;
+        }
     }
 
 }

--- a/webapp/src/app/resource/resource.module.ts
+++ b/webapp/src/app/resource/resource.module.ts
@@ -24,6 +24,8 @@ import { StrategyComponent } from './strategy/strategy.component';
 import { StrategyContentComponent } from './strategy/content/strategy-content.component';
 import { StrategyOverviewComponent } from './strategy/overview/strategy-overview.component';
 import { MetadataComponent } from './components/metadata/metadata.component';
+import { AppRoutingModule } from '../app-routing.module';
+import { RouterModule } from '@angular/router';
 
 export function getResourceComponents(resourceComponent: ResourceComponent) {
   return resourceComponent;
@@ -56,7 +58,8 @@ export function getResourceComponents(resourceComponent: ResourceComponent) {
   imports: [
     CommonModule,
     PipesModule,
-    SbdlCommonModule
+    SbdlCommonModule,
+    RouterModule
   ],
   entryComponents: [
     // Resource components are loaded dynamically so they need to be explicitly set here 

--- a/webapp/src/app/resource/strategy/content/strategy-content.component.html
+++ b/webapp/src/app/resource/strategy/content/strategy-content.component.html
@@ -1,5 +1,5 @@
 <div class="top-header">
-  <img src="/assets/images/yellow-spot.png" />
+  <img src="/assets/images/yellow-spot.png" alt="" />
   <sbdl-actions [model]= "model" (readingModeChanged)="emitReadingModeChanged($event)"></sbdl-actions>
 </div>
 <sbdl-header [model]="model" (attachmentsClicked)="scrollToAttachments()"></sbdl-header>

--- a/webapp/src/index.html
+++ b/webapp/src/index.html
@@ -6,7 +6,7 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link
-      href="https://fonts.googleapis.com/css?family=Montserrat:300,400,500,600,700|Open+Sans:400,600,700&display=swap"
+      href="https://fonts.googleapis.com/css?family=Montserrat:300,400,500,600,700|Open+Sans:300,400,600,700&display=swap"
       rel="stylesheet"
     />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />

--- a/webapp/src/ui-kit/_buttons.scss
+++ b/webapp/src/ui-kit/_buttons.scss
@@ -19,6 +19,7 @@
     color: $neutral-900;
     width: 100%;
     font-size: 1rem;
+    font-weight: 400;
     font-family: $font-family-title;
     text-align: left;
     text-transform: none;
@@ -47,6 +48,7 @@
     overflow: hidden;
 
     font-size: 0.9rem;
+    font-weight: 300;
     font-family: $font-family-body;
     text-align: left;
 


### PR DESCRIPTION
This PR addresses the follwing ui tweaks: 

- For the list of formative strategy links, there should be 16px between each link and only 3px between a link header and description.
- Add left border for Get Started, Differentiation, Formative Assessment Process (before psuedo element) that only shows when section is not highlighted.
- Playlist in metadata hover state and clickable
- Embedded strategy links should have underline on hover
- Strategy links should turn the same purple and underline on hover.  
- mdc-button in the outlines should be font-weight 400 (currently 500).
- mdc-button in the steps outline should be font-weight 300 (currently 400).
- Update Grades to be “Grades 6, 8, and 9” (coordinate with API spec on this)
