### PR TITLE
Fixes bugs around CDN cache invalidation new builds.

### DIFF
--- a/operations/terraform/main.tf
+++ b/operations/terraform/main.tf
@@ -1,3 +1,5 @@
+# S3 Buckets used by all environments for build and logging infrastructure
+
 resource "aws_s3_bucket" "logs" {
   bucket = "logs.${var.webapp_url_base}"
   acl = "log-delivery-write"
@@ -44,3 +46,4 @@ module "staging_env" {
   route53_zone_id = var.route53_zone_id
   webapp_url_base = var.webapp_url_base
 }
+

--- a/webapp/angular.json
+++ b/webapp/angular.json
@@ -102,6 +102,7 @@
               ]
             },
             "standalone" : {
+              "outputHashing": "all",
               "fileReplacements": [
                 {
                   "replace": "src/environments/environment.ts",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -8,7 +8,7 @@
     "start-stage": "npm run pre-build && ng serve --c stage -o",
     "build": "npm run pre-build && ng build --prod --aot --vendor-chunk",
     "build-stage": "npm run pre-build && ng build --c stage --aot --vendor-chunk",
-    "build-ci": "npm run pre-build-ci && ng build --c standalone --prod --aot --vendor-chunk",
+    "build-ci": "npm run pre-build-ci && ng build --c standalone --aot --vendor-chunk",
     "build-standalone": "npm run pre-build && ng build --c standalone --aot --vendor-chunk",
     "build-debug": "npm run pre-build && ng build",
     "build-standalone-debug": "npm run pre-build && ng build --c standalone",


### PR DESCRIPTION
- Change CloudFront configuration to use the native S3 origin configuration.
- Update the `standalone` build configuration to hash the application assets.