### PR TITLE
Fix the tooltip on the 'Copy to clipboard' icon in the share action.

### DIFF
--- a/webapp/src/app/resource/components/actions/actions.component.html
+++ b/webapp/src/app/resource/components/actions/actions.component.html
@@ -12,7 +12,7 @@
     <i class="fas fa-spinner fa-spin"></i>
   </div>
 </sbdl-button-icon>
-<sbdl-button-icon buttonTitle="Print" (click)="print()"><i class="far fa-print"></i></sbdl-button-icon>
+<sbdl-button-icon buttonTitle="Print"><i class="far fa-print"></i></sbdl-button-icon>
 <sbdl-button-icon buttonTitle="Toggle Reading Mode" [hidden]="hideReadingModeToggle" (click)="toggleReadingMode()">
   <div *ngIf="readingMode">
     <i class="far fa-compress-alt"></i>

--- a/webapp/src/app/resource/components/actions/actions.component.html
+++ b/webapp/src/app/resource/components/actions/actions.component.html
@@ -12,7 +12,7 @@
     <i class="fas fa-spinner fa-spin"></i>
   </div>
 </sbdl-button-icon>
-<sbdl-button-icon buttonTitle="Print"><i class="far fa-print"></i></sbdl-button-icon>
+<sbdl-button-icon buttonTitle="Print" (click)="print()"><i class="far fa-print"></i></sbdl-button-icon>
 <sbdl-button-icon buttonTitle="Toggle Reading Mode" [hidden]="hideReadingModeToggle" (click)="toggleReadingMode()">
   <div *ngIf="readingMode">
     <i class="far fa-compress-alt"></i>
@@ -26,8 +26,8 @@
       <h6>Share this resource</h6>
       <div class="copy-clipboard">
           <input #url readonly type="text" [value]="currentUrl">
-          <sbdl-button-icon (click)="copyToClipboard(url)">
-            <i class="fas fa-copy" title="Copy to clipboard"></i>
+          <sbdl-button-icon buttonTitle="Copy to clipboad" (click)="copyToClipboard(url)">
+            <i class="fas fa-copy"></i>
             <div class="copy-success" [hidden]="!showCopied">Copied!</div>
           </sbdl-button-icon>
       </div>


### PR DESCRIPTION
From Nohemi:

> When you hover over the "Copy to clipboard" icon in the share popup it correctly displays the tooltip. But if you move the mouse down just a bit to where it is still over the icon background but not exactly over the icon the tooltip changes to "undefined".

This PR fixes this bug.