### PR TITLE
DL-172 & DL-205

### DIFF
--- a/webapp/src/app/resource/components/actions/actions.component.html
+++ b/webapp/src/app/resource/components/actions/actions.component.html
@@ -15,7 +15,14 @@
     <i class="fas fa-spinner fa-spin"></i>
   </div>
 </sbdl-button-icon>
-<sbdl-button-icon buttonTitle="Print" (click)="print()"><i class="far fa-print"></i></sbdl-button-icon>
+<sbdl-button-icon buttonTitle="Print" (click)="togglePrintingMode()">
+  <div *ngIf="printingMode">
+    <i class="fas fa-print"></i>
+  </div>
+  <div *ngIf="!printingMode">
+    <i class="far fa-print"></i>
+  </div>
+</sbdl-button-icon>
 <sbdl-button-icon buttonTitle="Toggle Reading Mode" [hidden]="hideReadingModeToggle" (click)="toggleReadingMode()">
   <div *ngIf="readingMode">
     <i class="far fa-compress-alt"></i>

--- a/webapp/src/app/resource/components/outline/enhanced-printing/enhanced-printing.component.scss
+++ b/webapp/src/app/resource/components/outline/enhanced-printing/enhanced-printing.component.scss
@@ -10,8 +10,9 @@
     background-color: rgba($warning-100, 0.4);
     border-radius: $spacer-sm;
     color: $neutral-500;
-    margin: $spacer-xl $spacer $spacer $spacer;
+    margin: $spacer $spacer $spacer $spacer;
     padding: $spacer;
+    width: 16.5em;
 
     .dialog-buttons {
       display: flex;

--- a/webapp/src/app/resource/components/outline/outline.component.ts
+++ b/webapp/src/app/resource/components/outline/outline.component.ts
@@ -19,7 +19,7 @@ export class OutlineComponent implements OnInit {
   readingMode: boolean;
 
   @Input()
-  outline: DocumentOutline = Map<DocumentSectionType, DocumentSection>();
+  outline: DocumentOutline;
 
   mobile = false;
   private breakpointSmall = 500;

--- a/webapp/src/app/resource/instructional/content/instructional-content.component.html
+++ b/webapp/src/app/resource/instructional/content/instructional-content.component.html
@@ -1,8 +1,10 @@
 <div class="top-header">
   <img src="/assets/images/yellow-spot.png" alt="" />
   <sbdl-actions
-    [notesVisible]="notesVisible"
     [hasNotes]="notes.length > 0"
+    [notesVisible]="notesVisible"
+    [readingMode]="readingMode"
+    [printingMode]="printingMode"
     [resource]= "resource"
     (readingModeChanged)="emitReadingModeChanged($event)"
     (printingModeChanged)="emitPrintingModeChanged($event)"

--- a/webapp/src/app/resource/instructional/instructional-resource.component.html
+++ b/webapp/src/app/resource/instructional/instructional-resource.component.html
@@ -17,6 +17,8 @@
   <sbdl-instructional-content
     [notes]="notes"
     [notesVisible]="notesVisible"
+    [printingMode]="printingMode"
+    [readingMode]="readingMode"
     [outline]="outline"
     [resource]="resource"
     (outlineLoaded)="setOutline($event)"

--- a/webapp/src/app/resource/instructional/instructional-resource.component.html
+++ b/webapp/src/app/resource/instructional/instructional-resource.component.html
@@ -17,6 +17,7 @@
   <sbdl-instructional-content
     [notes]="notes"
     [notesVisible]="notesVisible"
+    [outline]="outline"
     [resource]="resource"
     (outlineLoaded)="setOutline($event)"
     (readingModeChanged)="readingModeChanged($event)"

--- a/webapp/src/app/resource/professional/content/professional-content.component.html
+++ b/webapp/src/app/resource/professional/content/professional-content.component.html
@@ -1,8 +1,10 @@
 <div class="top-header">
   <img src="/assets/images/yellow-spot.png" alt="" />
   <sbdl-actions
-    [notesVisible]="notesVisible"
     [hasNotes]="notes.length > 0"
+    [notesVisible]="notesVisible"
+    [readingMode]="readingMode"
+    [printingMode]="printingMode"
     [resource]="resource"
     (readingModeChanged)="emitReadingModeChanged($event)"
     (printingModeChanged)="emitPrintingModeChanged($event)"

--- a/webapp/src/app/resource/professional/professional-resource.component.html
+++ b/webapp/src/app/resource/professional/professional-resource.component.html
@@ -17,6 +17,7 @@
   <sbdl-professional-content
     [notes]="notes"
     [notesVisible]="notesVisible"
+    [outline]="outline"
     [resource]="resource"
     (outlineLoaded)="setOutline($event)"
     (printingModeChanged)="printingModeChanged($event)"

--- a/webapp/src/app/resource/professional/professional-resource.component.html
+++ b/webapp/src/app/resource/professional/professional-resource.component.html
@@ -17,6 +17,8 @@
   <sbdl-professional-content
     [notes]="notes"
     [notesVisible]="notesVisible"
+    [printingMode]="printingMode"
+    [readingMode]="readingMode"
     [outline]="outline"
     [resource]="resource"
     (outlineLoaded)="setOutline($event)"

--- a/webapp/src/app/resource/resource-content.component.ts
+++ b/webapp/src/app/resource/resource-content.component.ts
@@ -22,6 +22,9 @@ export class ResourceContentComponent implements OnInit {
     @Input()
     notesVisible: boolean;
 
+    @Input()
+    outline: DocumentOutline;
+
     @Output()
     outlineLoaded = new EventEmitter<DocumentOutline>();
 
@@ -33,8 +36,6 @@ export class ResourceContentComponent implements OnInit {
 
     @Output()
     notesVisibilityChanged = new EventEmitter<boolean>();
-
-    protected outline: DocumentOutline = Map<DocumentSectionType, DocumentSection>();
 
     constructor() { }
 

--- a/webapp/src/app/resource/resource-content.component.ts
+++ b/webapp/src/app/resource/resource-content.component.ts
@@ -23,6 +23,12 @@ export class ResourceContentComponent implements OnInit {
     notesVisible: boolean;
 
     @Input()
+    printingMode: boolean;
+
+    @Input()
+    readingMode: boolean;
+
+    @Input()
     outline: DocumentOutline;
 
     @Output()

--- a/webapp/src/app/resource/resource.component.scss
+++ b/webapp/src/app/resource/resource.component.scss
@@ -64,6 +64,7 @@
     }
 
     nav sbdl-outline,
+    nav sbdl-enhanced-printing,
     aside sbdl-resource-properties {
       position: fixed;
       max-height: 100%;
@@ -79,11 +80,13 @@
       }
     }
 
-    nav sbdl-outline {
+    nav sbdl-outline,
+    nav sbdl-enhanced-printing {
         width: var(--nav-width);
     }
 
-    nav sbdl-outline:hover {
+    nav sbdl-outline:hover,
+    nav sbdl-enhanced-printing:hover {
         width: 331px;
     }
 
@@ -126,6 +129,7 @@
         }
 
         nav sbdl-outline,
+        nav sbdl-enhanced-printing,
         aside sbdl-detailed-metadata,
         aside sbdl-resource-properties {
           position: relative;
@@ -159,7 +163,7 @@
   :host {
     display: block;
 
-    .outline, nav, sbdl-outline {
+    .outline, nav, sbdl-outline, sbdl-enhanced-printing {
       display: none;
     }
 

--- a/webapp/src/app/resource/resource.component.ts
+++ b/webapp/src/app/resource/resource.component.ts
@@ -1,8 +1,9 @@
 import { AfterViewInit, ChangeDetectorRef, HostBinding, OnInit } from '@angular/core';
 import { DomSanitizer, SafeStyle, Title } from '@angular/platform-browser';
+import { Map } from 'immutable';
 import { Resource } from '../data/resource/model/resource.model';
 import { Note } from '../data/notes/model/note.model';
-import { DocumentOutline } from './components/outline/document-outline.model';
+import { DocumentOutline, DocumentSection, DocumentSectionType } from './components/outline/document-outline.model';
 import { ResourceTypePipe } from '../pipes/resource-type.pipe';
 
 /**
@@ -13,7 +14,7 @@ export class ResourceComponent implements AfterViewInit, OnInit {
 
   resource: Resource;
   notes: Note[];
-  outline: DocumentOutline;
+  outline: DocumentOutline = Map<DocumentSectionType, DocumentSection>();
   readingMode: boolean = window.innerWidth < 1200;
   printingMode = false;
   notesVisible = false;

--- a/webapp/src/app/resource/resource.component.ts
+++ b/webapp/src/app/resource/resource.component.ts
@@ -13,11 +13,12 @@ import { ResourceTypePipe } from '../pipes/resource-type.pipe';
 export class ResourceComponent implements AfterViewInit, OnInit {
 
   resource: Resource;
+  notesVisible = false;
   notes: Note[];
   outline: DocumentOutline = Map<DocumentSectionType, DocumentSection>();
-  readingMode: boolean = window.innerWidth < 1200;
   printingMode = false;
-  notesVisible = false;
+  readingMode = false; // will get set properly by ActionsComponent when it loads.
+
   navWidth = 331;
   cssVarStyle: SafeStyle;
 
@@ -49,6 +50,7 @@ export class ResourceComponent implements AfterViewInit, OnInit {
 
   readingModeChanged(readingMode: boolean) {
     this.readingMode = readingMode;
+
     this.setCssVarStyle();
   }
 

--- a/webapp/src/app/resource/strategy/content/strategy-content.component.html
+++ b/webapp/src/app/resource/strategy/content/strategy-content.component.html
@@ -1,8 +1,10 @@
 <div class="top-header">
   <img src="/assets/images/yellow-spot.png" alt="" />
   <sbdl-actions
-    [notesVisible]="notesVisible"
     [hasNotes]="notes.length > 0"
+    [notesVisible]="notesVisible"
+    [readingMode]="readingMode"
+    [printingMode]="printingMode"
     [resource]="resource"
     (readingModeChanged)="emitReadingModeChanged($event)"
     (printingModeChanged)="emitPrintingModeChanged($event)"

--- a/webapp/src/app/resource/strategy/strategy-resource.component.html
+++ b/webapp/src/app/resource/strategy/strategy-resource.component.html
@@ -17,6 +17,7 @@
   <sbdl-strategy-content
     [notes]="notes"
     [notesVisible]="notesVisible"
+    [outline]="outline"
     [resource]="resource"
     (outlineLoaded)="setOutline($event)"
     (readingModeChanged)="readingModeChanged($event)"

--- a/webapp/src/app/resource/strategy/strategy-resource.component.html
+++ b/webapp/src/app/resource/strategy/strategy-resource.component.html
@@ -18,6 +18,8 @@
     [notes]="notes"
     [notesVisible]="notesVisible"
     [outline]="outline"
+    [printingMode]="printingMode"
+    [readingMode]="readingMode"
     [resource]="resource"
     (outlineLoaded)="setOutline($event)"
     (readingModeChanged)="readingModeChanged($event)"


### PR DESCRIPTION
DL-172 DL-205 Fixes related to reading mode.

* DL-172: Fixes reading mode interaction with page resizes. The previous behavior tried to respect your current setting but did not do so when crossing the breakpoint between small and large page widths. When moving to small sizes reading mode is always engaged. This is correct behavior. However when moving from small to large reading mode would always be disengaged. This is incorrect and leads to immediately un-intuitive behavior if the user crosses the breakpoint temporarily during a resize.

  With this new behavior the page still automatically switches to reading mode when the page size drops below the breakpoint but now it remembers your previous setting when crossing back over to large sizes again. Additionally we delay the final resizing logic until 200ms after the last resize event fires. Ideally this means that the resize logic only fires once the user has completed resizing the page. However, this is primarily a performance optimzation as the new transition logic is robust enough to behave correctly even when called as frequently as it was previously.

* DL-205: Fixes the display of the enhanced printing UI when reading mode is engaged.

