### PR TITLE
DL-234 Add missing outline ordering for Accessibility Strategies.

### DIFF
--- a/webapp/src/app/resource/components/outline/outline.component.ts
+++ b/webapp/src/app/resource/components/outline/outline.component.ts
@@ -39,7 +39,7 @@ export class OutlineComponent implements OnInit {
       [ DST.Overview, DST.StepByStep, DST.Attachments, DST.ThingsToConsider, DST.StrategyInAction ])
     .set(
       ResourceType.AccessibilityStrategy,
-      [ DST.Overview ])
+      [ DST.Overview, DST.StepByStep, DST.Attachments, DST.ThingsToConsider, DST.StrategyInAction ])
     .set(
       ResourceType.ConnectionsPlaylist,
       [ DST.PlaylistTopics, DST.ThingsToConsider, DST.Overview, DST.PlaylistInterim ]);


### PR DESCRIPTION
Previously:
![DL-234](https://user-images.githubusercontent.com/280899/71913063-78e74a80-312b-11ea-8ca0-70a3137f78f0.png)

Now:
![image](https://user-images.githubusercontent.com/280899/71912619-b5ff0d00-312a-11ea-9685-6334655330d0.png)
