### PR TITLE
DL-186 Fix padding for lists in Read More components.

### DIFF
--- a/webapp/src/app/common/controls/read-more/read-more.component.html
+++ b/webapp/src/app/common/controls/read-more/read-more.component.html
@@ -5,4 +5,8 @@
     [innerHtml]="text"
     >
 </div>
-<a *ngIf="collapsible" class="more-less" href="javascript:void(0)" (click)="toggleCollapsed()">{{ collapsed ? '... more' : 'less' }}</a>
+<a *ngIf="collapsible"
+   class="more-less"
+   href="javascript:void(0)"
+   (click)="toggleCollapsed()"
+   aria-hidden="true">{{ collapsed ? '... more' : 'less' }}</a>

--- a/webapp/src/app/common/controls/read-more/read-more.component.scss
+++ b/webapp/src/app/common/controls/read-more/read-more.component.scss
@@ -12,7 +12,7 @@
       margin-bottom: 0;
     }
     ul {
-      margin-top: 0;
+      margin: 0;
     }
   }
 }

--- a/webapp/src/app/common/controls/read-more/read-more.component.ts
+++ b/webapp/src/app/common/controls/read-more/read-more.component.ts
@@ -3,7 +3,7 @@ import { getCssVar } from '../../utils';
 import { SafeStyle, DomSanitizer } from '@angular/platform-browser';
 
 /**
- * This component shows a "more" link and truncates the given text if the length is more 
+ * This component shows a "more" link and truncates the given text if the length is more
  * than the MaxNumberOfCharacters.,  When expanded, "more" changes to "less".
  */
 @Component({
@@ -27,16 +27,16 @@ export class ReadMoreComponent implements OnInit, AfterViewInit {
 
   @ViewChild('textContainer', { static: true })
   textContainer: ElementRef;
-  
+
   private maxHeightInPx = 44;
 
   cssVarStyle: SafeStyle;
-  collapsed: boolean = true;
-  collapsible: boolean = false;
+  collapsed = true;
+  collapsible = false;
 
   private _text: string;
 
-  constructor() { 
+  constructor() {
   }
 
   ngOnInit() {
@@ -52,7 +52,7 @@ export class ReadMoreComponent implements OnInit, AfterViewInit {
   }
 
   private onTextChanges() {
-    if(this.textContainer && this.textContainer.nativeElement) {
+    if (this.textContainer && this.textContainer.nativeElement) {
       const contentHeight = this.textContainer.nativeElement.offsetHeight;
       this.collapsible = contentHeight > this.maxHeightInPx;
       this.collapsed = this.collapsible;


### PR DESCRIPTION
The ReadMoreComponent is intended to add a "more/less" link when the
wrapped text contains more than two lines. The way we implement this is
based on interogating the element for it's total height. If the total
height is greater than two lines should be based on the known font size
then we add the more/less link. This whole calculation depends on there
not being excess padding internally within the wrapped text.

Additionally, we now hide the more/less link from screen readers (as
they will just read the whole block).