### PR TITLE
DL-198 Fixes metadata formating in printed layouts.

### DIFF
--- a/webapp/src/app/layout/app-container/app-container.component.scss
+++ b/webapp/src/app/layout/app-container/app-container.component.scss
@@ -41,7 +41,3 @@
     }
   }
 }
-
-@page {
-  margin-bottom: 5cm;
-}

--- a/webapp/src/app/resource/components/header/header.component.scss
+++ b/webapp/src/app/resource/components/header/header.component.scss
@@ -89,6 +89,8 @@
 
 @media only print {
   :host {
+    margin-bottom: 0;
+
     .attachments-btn { display: none; }
     .print-url { display: block; }
   }

--- a/webapp/src/app/resource/instructional/content/instructional-content.component.html
+++ b/webapp/src/app/resource/instructional/content/instructional-content.component.html
@@ -1,22 +1,3 @@
-<div class="top-header">
-  <img src="/assets/images/yellow-spot.png" alt="" />
-  <sbdl-actions
-    [hasNotes]="notes.length > 0"
-    [notesVisible]="notesVisible"
-    [readingMode]="readingMode"
-    [printingMode]="printingMode"
-    [resource]= "resource"
-    (readingModeChanged)="emitReadingModeChanged($event)"
-    (printingModeChanged)="emitPrintingModeChanged($event)"
-    (notesVisibilityChanged)="emitNotesVisibilityChanged($event)"
-  ></sbdl-actions>
-</div>
-
-<sbdl-header
-  [resource]="resource"
-  (attachmentsClicked)="scrollToAttachments()"
-></sbdl-header>
-
 <sbdl-instructional-get-started
   [resource]="resource"
   (sectionLoaded)="addDocumentSection($event)"

--- a/webapp/src/app/resource/instructional/get-started/instructional-get-started.component.scss
+++ b/webapp/src/app/resource/instructional/get-started/instructional-get-started.component.scss
@@ -26,9 +26,3 @@
       }
     }
 }
-
-@media only print {
-  :host {
-    margin-top: 14rem;
-  }
-}

--- a/webapp/src/app/resource/instructional/instructional-resource.component.html
+++ b/webapp/src/app/resource/instructional/instructional-resource.component.html
@@ -13,6 +13,26 @@
     (documentOutlineChanged)="setOutline($event)"
   ></sbdl-enhanced-printing>
 </nav>
+<header class="resource-header">
+  <div class="top-header">
+    <img src="/assets/images/yellow-spot.png" alt="" />
+    <sbdl-actions
+      [hasNotes]="notes.length > 0"
+      [notesVisible]="notesVisible"
+      [readingMode]="readingMode"
+      [printingMode]="printingMode"
+      [resource]="resource"
+      (readingModeChanged)="readingModeChanged($event)"
+      (printingModeChanged)="printingModeChanged($event)"
+      (notesVisibilityChanged)="notesVisibilityChanged($event)"
+    ></sbdl-actions>
+  </div>
+
+  <sbdl-header
+    [resource]="resource"
+    (attachmentsClicked)="scrollToAttachments()"
+  ></sbdl-header>
+</header>
 <main class="resource-content">
   <sbdl-instructional-content
     [notes]="notes"

--- a/webapp/src/app/resource/playlist/content/playlist-content.component.html
+++ b/webapp/src/app/resource/playlist/content/playlist-content.component.html
@@ -1,19 +1,3 @@
-<div class="top-header">
-  <img src="/assets/images/yellow-spot.png" alt="" />
-  <sbdl-actions
-    [hasNotes]="notes.length > 0"
-    [notesVisible]="notesVisible"
-    [readingMode]="readingMode"
-    [printingMode]="printingMode"
-    [resource]= "resource"
-    (readingModeChanged)="emitReadingModeChanged($event)"
-    (printingModeChanged)="emitPrintingModeChanged($event)"
-    (notesVisibilityChanged)="emitNotesVisibilityChanged($event)"
-  ></sbdl-actions>
-</div>
-
-<sbdl-header [resource]="resource"></sbdl-header>
-
 <sbdl-playlist-topics
   [readingMode]="readingMode"
   [resource]="resource"

--- a/webapp/src/app/resource/playlist/playlist-resource.component.html
+++ b/webapp/src/app/resource/playlist/playlist-resource.component.html
@@ -13,6 +13,23 @@
     (documentOutlineChanged)="setOutline($event)"
   ></sbdl-enhanced-printing>
 </nav>
+<header class="resource-header">
+  <div class="top-header">
+    <img src="/assets/images/yellow-spot.png" alt="" />
+    <sbdl-actions
+      [hasNotes]="notes.length > 0"
+      [notesVisible]="notesVisible"
+      [readingMode]="readingMode"
+      [printingMode]="printingMode"
+      [resource]="resource"
+      (readingModeChanged)="readingModeChanged($event)"
+      (printingModeChanged)="printingModeChanged($event)"
+      (notesVisibilityChanged)="notesVisibilityChanged($event)"
+    ></sbdl-actions>
+  </div>
+
+  <sbdl-header [resource]="resource" ></sbdl-header>
+</header>
 <main class="resource-content">
   <sbdl-playlist-content
     [notes]="notes"

--- a/webapp/src/app/resource/printable-section.component.scss
+++ b/webapp/src/app/resource/printable-section.component.scss
@@ -1,4 +1,5 @@
 @import "colors";
+@import "spacing";
 
 :host {
   --print-display: block;
@@ -25,5 +26,9 @@
     display: var(--print-display);
     position: var(--print-position);
     visibility: var(--print-visibility);
+
+    hr {
+      margin-bottom: $spacer;
+    }
   }
 }

--- a/webapp/src/app/resource/professional/content/professional-content.component.html
+++ b/webapp/src/app/resource/professional/content/professional-content.component.html
@@ -1,22 +1,3 @@
-<div class="top-header">
-  <img src="/assets/images/yellow-spot.png" alt="" />
-  <sbdl-actions
-    [hasNotes]="notes.length > 0"
-    [notesVisible]="notesVisible"
-    [readingMode]="readingMode"
-    [printingMode]="printingMode"
-    [resource]="resource"
-    (readingModeChanged)="emitReadingModeChanged($event)"
-    (printingModeChanged)="emitPrintingModeChanged($event)"
-    (notesVisibilityChanged)="emitNotesVisibilityChanged($event)"
-  ></sbdl-actions>
-</div>
-
-<sbdl-header
-  [resource]="resource"
-  (attachmentsClicked)="scrollToAttachments()"
-></sbdl-header>
-
 <sbdl-professional-overview
   [resource]="resource"
   (sectionLoaded)="addDocumentSection($event)"

--- a/webapp/src/app/resource/professional/professional-resource.component.html
+++ b/webapp/src/app/resource/professional/professional-resource.component.html
@@ -13,6 +13,26 @@
     (documentOutlineChanged)="setOutline($event)"
   ></sbdl-enhanced-printing>
 </nav>
+<header class="resource-header">
+  <div class="top-header">
+    <img src="/assets/images/yellow-spot.png" alt="" />
+    <sbdl-actions
+      [hasNotes]="notes.length > 0"
+      [notesVisible]="notesVisible"
+      [readingMode]="readingMode"
+      [printingMode]="printingMode"
+      [resource]="resource"
+      (readingModeChanged)="readingModeChanged($event)"
+      (printingModeChanged)="printingModeChanged($event)"
+      (notesVisibilityChanged)="notesVisibilityChanged($event)"
+    ></sbdl-actions>
+  </div>
+
+  <sbdl-header
+    [resource]="resource"
+    (attachmentsClicked)="scrollToAttachments()"
+  ></sbdl-header>
+</header>
 <main class="resource-content">
   <sbdl-professional-content
     [notes]="notes"

--- a/webapp/src/app/resource/resource-content.component.scss
+++ b/webapp/src/app/resource/resource-content.component.scss
@@ -8,13 +8,6 @@
     flex-direction: column;
     max-width: none;
 
-    .top-header {
-        display: flex;
-        justify-content: space-between;
-        width: 100%;
-        align-items: baseline;
-    }
-
     hr {
         width:100%;
         box-sizing: border-box;
@@ -34,11 +27,5 @@
 @media only print {
   :host {
     display: block;
-
-    .top-header {
-      margin-top: $spacer-lg;
-
-      img { display: none; }
-    }
   }
 }

--- a/webapp/src/app/resource/resource-content.component.ts
+++ b/webapp/src/app/resource/resource-content.component.ts
@@ -53,13 +53,6 @@ export class ResourceContentComponent implements OnInit {
       this.outlineLoaded.emit(this.outline);
     }
 
-    scrollToAttachments() {
-      if (this.outline && this.outline.has(DocumentSectionType.Attachments)) {
-        this.outline.get(DocumentSectionType.Attachments).elementRef
-          .scrollIntoView({behavior: 'smooth', block: 'start', inline: 'nearest'});
-      }
-    }
-
     emitReadingModeChanged(event) {
       this.readingModeChanged.emit(event);
     }

--- a/webapp/src/app/resource/resource.component.scss
+++ b/webapp/src/app/resource/resource.component.scss
@@ -2,12 +2,18 @@
 @import "spacing";
 
 :host {
-    display: flex;
-    align-items: stretch;
+    display: grid;
+    grid-template:
+      "outline header properties"
+      "outline content properties"
+      / auto auto auto;
+    justify-items: stretch;
     justify-content: space-between;
-    max-width: none;
+
+    max-width: unset;
 
     .outline {
+        grid-area: outline;
         box-sizing: border-box;
         width: var(--nav-width);
         min-width: var(--nav-width);
@@ -31,6 +37,20 @@
         overflow-x:initial;
     }
 
+    .resource-header {
+        grid-area: header;
+        box-sizing: border-box;
+        max-width: calc(var(--measure) + 8rem);
+        padding: 0 $spacer-lg;
+
+        .top-header {
+            display: flex;
+            justify-content: space-between;
+            width: 100%;
+            align-items: baseline;
+        }
+    }
+
     .resource-properties:hover {
         width: 331px;
         min-width: 331px;
@@ -39,12 +59,15 @@
     }
 
     .resource-content {
+        grid-area: content;
         padding: 0 $spacer-lg;
         box-sizing: border-box;
-        max-width: none;
+        max-width: calc(var(--measure) + 8rem);
         z-index: 1;
     }
+
     .resource-properties {
+        grid-area: properties;
         width: var(--nav-width);
         min-width: var(--nav-width);
         transition-property: width, min-width, margin-left, z-index;
@@ -52,7 +75,7 @@
         transition-duration: 0.5s;
         transition-timing-function: ease-in;
 
-        box-shadow: inset 10px 0px 18px -10px rgba(182, 109, 109, 0.2);
+        box-shadow: inset 10px 0px 18px -10px rgba(0, 0, 0, 0.2);
 
         background-image: url('/assets/images/green-spot-2.png'), url('/assets/images/yellow-spot-2.png');
         background-repeat: no-repeat;
@@ -119,13 +142,14 @@
         }
     }
 }
+
 @media only screen and (max-width: $breakpoint-sm) {
     :host {
         --nav-width: 100vw;
         flex-direction: column;
         > * {
             width: 100%;
-            max-width: none;
+            max-width: unset;
         }
 
         nav sbdl-outline,
@@ -140,7 +164,7 @@
         .outline:hover, .resource-properties:hover {
             width: 100%;
             transition: none;
-            min-width: none;           
+            min-width: unset;
         }
 
         .resource-properties {
@@ -161,7 +185,7 @@
 
 @media only print {
   :host {
-    display: block;
+    grid-template: "header" "properties" "content" / auto;
 
     .outline, nav, sbdl-outline, sbdl-enhanced-printing {
       display: none;
@@ -171,16 +195,19 @@
       position: initial;
     }
 
+    .top-header {
+      img { display: none; }
+    }
+
     .resource-properties {
       background-image: none;
       box-shadow: none;
-      min-width: none;
+      padding: 0 $spacer-xl;
+      position: relative;
+      max-width: calc(var(--measure) + 8rem);
+      min-width: unset;
       min-height: unset;
       width: unset;
-
-      position: absolute;
-      top: 14rem;
-      left: 4rem;
     }
 
     &::ng-deep {

--- a/webapp/src/app/resource/resource.component.ts
+++ b/webapp/src/app/resource/resource.component.ts
@@ -66,6 +66,13 @@ export class ResourceComponent implements AfterViewInit, OnInit {
     this.notes = notes;
   }
 
+  scrollToAttachments() {
+    if (this.outline && this.outline.has(DocumentSectionType.Attachments)) {
+      this.outline.get(DocumentSectionType.Attachments).elementRef
+        .scrollIntoView({behavior: 'smooth', block: 'start', inline: 'nearest'});
+    }
+  }
+
   private updatePrintStyles() {
     this.outline.forEach(section => {
       if (section.component) {

--- a/webapp/src/app/resource/strategy/content/strategy-content.component.html
+++ b/webapp/src/app/resource/strategy/content/strategy-content.component.html
@@ -1,22 +1,3 @@
-<div class="top-header">
-  <img src="/assets/images/yellow-spot.png" alt="" />
-  <sbdl-actions
-    [hasNotes]="notes.length > 0"
-    [notesVisible]="notesVisible"
-    [readingMode]="readingMode"
-    [printingMode]="printingMode"
-    [resource]="resource"
-    (readingModeChanged)="emitReadingModeChanged($event)"
-    (printingModeChanged)="emitPrintingModeChanged($event)"
-    (notesVisibilityChanged)="emitNotesVisibilityChanged($event)"
-  ></sbdl-actions>
-</div>
-
-<sbdl-header
-  [resource]="resource"
-  (attachmentsClicked)="scrollToAttachments()"
-></sbdl-header>
-
 <sbdl-strategy-overview
   [resource]="resource"
   (sectionLoaded)="addDocumentSection($event)"

--- a/webapp/src/app/resource/strategy/strategy-resource.component.html
+++ b/webapp/src/app/resource/strategy/strategy-resource.component.html
@@ -13,6 +13,26 @@
     (documentOutlineChanged)="setOutline($event)"
   ></sbdl-enhanced-printing>
 </nav>
+<header class="resource-header">
+  <div class="top-header">
+    <img src="/assets/images/yellow-spot.png" alt="" />
+    <sbdl-actions
+      [hasNotes]="notes.length > 0"
+      [notesVisible]="notesVisible"
+      [readingMode]="readingMode"
+      [printingMode]="printingMode"
+      [resource]="resource"
+      (readingModeChanged)="readingModeChanged($event)"
+      (printingModeChanged)="printingModeChanged($event)"
+      (notesVisibilityChanged)="notesVisibilityChanged($event)"
+    ></sbdl-actions>
+  </div>
+
+  <sbdl-header
+    [resource]="resource"
+    (attachmentsClicked)="scrollToAttachments()"
+  ></sbdl-header>
+</header>
 <main class="resource-content">
   <sbdl-strategy-content
     [notes]="notes"


### PR DESCRIPTION
Previously the resource header (with the title, etc) was part of the
same element as the main resource content. Positioning the metadata
after the header but before the main content required manually adding
padding and absoutely positioning the metadata block. To do this
properly we would need to inspect the actiual sizes of these elements at
print-time to accurately calculate the padding needed.

This commit bypasses all of that by instead breaking the resource header
out as a separate component and switching to a grid layout so that we
can let the browser handle all of the layout calculations.