### PR TITLE
DL-229 Best-effort fix for footer formating in printed resources.

### DIFF
--- a/webapp/src/app/layout/footer/footer.component.scss
+++ b/webapp/src/app/layout/footer/footer.component.scss
@@ -74,6 +74,9 @@
 @media only print {
   :host {
 
+    /* See the note in src/styles.scss. Ideally, once CSS Paged Media is
+     * implemented in browsers, we can replace all of the following with just
+     * 'display: none' on the :host element. */
     .footer  {
       .footer-links {
         display: none;
@@ -82,10 +85,14 @@
       hr { display: none; }
 
       .copyright {
+        margin: 0;
         position: fixed;
-        bottom: -2rem;
+        bottom: 0;
         right: $spacer-xl;
 
+        span {
+          padding: 0;
+        }
         img { display: none; }
       }
     }

--- a/webapp/src/styles.scss
+++ b/webapp/src/styles.scss
@@ -44,4 +44,18 @@ body {
   }
 
   .print-only { display: block; }
+
+  @page {
+    /* This is what we actually want to use for the printed footers. But CSS3
+     * page-margin boxes are part of the paged media draft document and not
+     * implemented yet (see https://www.w3.org/TR/css-page-3/).
+
+    @bottom-right {
+      color: $neutral-300;
+      content: "© 2019 The Regents of the University of California";
+      font-size: 80%;
+      margin: 0 $spacer;
+    }
+    */
+  }
 }


### PR DESCRIPTION
The actual fix for this requires technology that's not available yet.
CSS Paged Media provides the means to format footers in the way that we
wish but is not yet implemented in our target browsers. For the time
being this adjusts some of the margins and positioning of the footer to
better situate it on the page but there is no real way to create a
persistent margin for the page content that does not also serve as a
margin for the footer.

In other words, if I add a 2cm margin to the bottom of the page the
footer element must also respect that margin. Trying to put the footer
within the margin pushes it onto the next page. Adding margin on the
footer itself doesn't work because the footer is fixed (has to be to
appear on every page) and fixed elements are not considered when laying
out the primary page flow (so the footer margin doesn't affect the body
content). Adding a margin at the bottom of the content only affects the
last page. Using `@page { margin: 2cm; }` causes the issue described in
the first paragraph (footer is affected).