### PR TITLE
DL-312 Add consistent loading behavior, don't search the whole DB.

### DIFF
--- a/webapp/src/app/app.component.spec.ts
+++ b/webapp/src/app/app.component.spec.ts
@@ -33,11 +33,4 @@ describe('AppComponent', () => {
     const app = fixture.debugElement.componentInstance;
     expect(app.title).toEqual('sb-digital-library');
   });
-
-  // it('should render title in a h1 tag', () => {
-  //   const fixture = TestBed.createComponent(AppComponent);
-  //   fixture.detectChanges();
-  //   const compiled = fixture.debugElement.nativeElement;
-  //   expect(compiled.querySelector('h1').textContent).toContain('Welcome to sb-digital-library!');
-  // });
 });

--- a/webapp/src/app/app.component.ts
+++ b/webapp/src/app/app.component.ts
@@ -1,10 +1,8 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';
 import { VERSION } from 'src/environments/version';
 import { AppConfig } from './common/config/app.config';
 import { RouterService } from './router.service';
-import { OKTA_CALLBACK_PATH } from './common/constants';
 
 @Component({
   selector: 'sbdl-root',
@@ -17,12 +15,8 @@ export class AppComponent implements OnInit {
   env = AppConfig.settings ? AppConfig.settings.env.name : '<not set>';
   appVersion = VERSION;
 
-  private oldPath = '/';
-
   constructor(
     angulartics2GoogleAnalytics: Angulartics2GoogleAnalytics,
-    private route: ActivatedRoute,
-    private router: Router,
     private routerService: RouterService
   ) {
     if (AppConfig.settings && AppConfig.settings.enableAnalytics) {
@@ -31,30 +25,9 @@ export class AppComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.router.events.subscribe((evt) => {
-      if (evt instanceof NavigationEnd) {
-        const newPath = this.urlPathPart(evt.url);
-        if (newPath !== this.oldPath) {
-          window.scrollTo(0, 0);
-        }
-        this.oldPath = newPath;
-      }
-    });
-
-    this.route.fragment.subscribe((fragment) => {
-      if (fragment && !this.router.url.includes(OKTA_CALLBACK_PATH)) {
-        setTimeout(() => {
-          document.querySelector('#' + fragment).scrollIntoView({behavior: 'smooth'});
-        });
-      }
-    });
 
     // Gracefully redirect to error pages.
     this.routerService.setRouteErrorHandler();
   }
 
-  private urlPathPart(url: string): string {
-    const PATH_REGEX = /(^[^?&;#]+)/;
-    return url.match(PATH_REGEX)[1] || '';
-  }
 }

--- a/webapp/src/app/app.module.spec.ts
+++ b/webapp/src/app/app.module.spec.ts
@@ -7,8 +7,14 @@ import { mockUser } from './data/mock-data';
 import { MockDataService } from './data/mock-data.service';
 
 // Common AppModule mocks here.
+export const dummyObservable = {
+  subscribe: () => {},
+  unsubscribe: () => {}
+};
+
 export const mockRootActivatedRouteSnapshot = {
-    snapshot: { data: { currentUser: mockUser } }
+    snapshot: { data: { currentUser: mockUser } },
+    fragment: dummyObservable
 };
 
 export function mockAppConfig() {

--- a/webapp/src/app/common/controls/text-field/text-field.component.html
+++ b/webapp/src/app/common/controls/text-field/text-field.component.html
@@ -7,8 +7,14 @@
     (keydown.enter)="onIconClick($event)"
     [(ngModel)]="model"
     [value]="model || ''"
+    [disabled]="disabled"
     [placeholder]="placeholder || ''" >
-  <sbdl-button class="primary" (click)="onIconClick($event)">
+
+  <sbdl-button
+    class="primary"
+    (click)="onIconClick($event)"
+    [disabled]="disabled" >
+
     <i *ngIf="fontAwesomeIcon" class="far {{fontAwesomeIcon}}" tabindex="0" role="button"></i>
   </sbdl-button>
   <div class="mdc-notched-outline">

--- a/webapp/src/app/common/controls/text-field/text-field.component.ts
+++ b/webapp/src/app/common/controls/text-field/text-field.component.ts
@@ -19,6 +19,9 @@ export class TextFieldComponent implements OnInit, AfterViewInit {
   @Input()
   model: string;
 
+  @Input()
+  disabled: boolean;
+
   @Output()
   submit = new EventEmitter<string>();
 

--- a/webapp/src/app/common/utils.ts
+++ b/webapp/src/app/common/utils.ts
@@ -45,6 +45,11 @@ export function makeQueryString(params: Params): string {
   return Object.entries(params).map(e => `${e[0]}=${e[1]}`).join('&');
 }
 
+export function urlPathPart(url: string): string {
+  const PATH_REGEX = /(^[^?&;#]+)/;
+  return url.match(PATH_REGEX)[1] || '';
+}
+
 /**
  * From: https://stackoverflow.com/questions/25312134/how-to-test-rendering-speed-in-angular
  */

--- a/webapp/src/app/data/search/search.service.ts
+++ b/webapp/src/app/data/search/search.service.ts
@@ -80,6 +80,21 @@ export class SearchService {
       }))
     );
   }
+  public paramsToRequestModel(params: any): SearchRequestModel {
+    if (Object.keys(params).length === 0) {
+      return null;
+    }
+
+    return {
+      Search_Text: params.query || '',
+      Claim: this.splitToArray(params.claims),
+      Grade: this.splitToArray(params.grades),
+      Standard: this.splitToArray(params.standards),
+      Subject: this.splitToArray(params.subjects),
+      Target: this.splitToArray(params.targets),
+      Resource_Type: this.splitToArray(params.resourceTypes)
+    };
+  }
 
   private hasNextPage(page: any): boolean {
     return page['hydra:view'].hasOwnProperty('hydra:next');
@@ -244,18 +259,6 @@ export class SearchService {
       .filter(f => f);
 
     return filters;
-  }
-
-  public paramsToRequestModel(params: any): SearchRequestModel {
-    return {
-      Search_Text: params.query || '',
-      Claim: this.splitToArray(params.claims),
-      Grade: this.splitToArray(params.grades),
-      Standard: this.splitToArray(params.standards),
-      Subject: this.splitToArray(params.subjects),
-      Target: this.splitToArray(params.targets),
-      Resource_Type: this.splitToArray(params.resourceTypes)
-    };
   }
 
   private splitToArray(param: string) {

--- a/webapp/src/app/home/home.component.html
+++ b/webapp/src/app/home/home.component.html
@@ -18,7 +18,9 @@
   Educator-created lessons, activities, strategies, and professional
   development to help tailor instruction and boost learning.
   </p>
-  <sbdl-search [filters]="filters"></sbdl-search>
+  <sbdl-search
+    [showHeadings]="false"
+    [filters]="filters"></sbdl-search>
 </main>
 
 <hr/>

--- a/webapp/src/app/layout/app-container/app-container.component.html
+++ b/webapp/src/app/layout/app-container/app-container.component.html
@@ -1,5 +1,5 @@
 <div class="app-container">
-  <a href="{{location.path()}}#main" class="skip-link">&nbsp;Skip to the main content.</a>
+  <a href="{{locationPath}}#main" class="skip-link">&nbsp;Skip to the main content.</a>
   <sbdl-navigation role="navigation"></sbdl-navigation>
   <div class="router-outlet" role="main">
     <div *ngIf="routeLoading" class="route-loader">

--- a/webapp/src/app/layout/app-container/app-container.component.html
+++ b/webapp/src/app/layout/app-container/app-container.component.html
@@ -1,7 +1,15 @@
 <div class="app-container">
   <a href="{{location.path()}}#main" class="skip-link">&nbsp;Skip to the main content.</a>
   <sbdl-navigation role="navigation"></sbdl-navigation>
-  <div class="router-outlet" role="main"><router-outlet></router-outlet></div>
+  <div class="router-outlet" role="main">
+    <div *ngIf="routeLoading" class="route-loader">
+      <div class="spinner-container">
+        <i class="fas fa-spinner fa-pulse"></i>
+      </div>
+    </div>
+    <router-outlet>
+    </router-outlet>
+  </div>
   <sbdl-footer></sbdl-footer>
 </div>
 

--- a/webapp/src/app/layout/app-container/app-container.component.scss
+++ b/webapp/src/app/layout/app-container/app-container.component.scss
@@ -1,3 +1,4 @@
+@import "colors";
 @import "spacing";
 
 .app-container {
@@ -31,12 +32,35 @@
 
   .router-outlet {
     grid-area: router-outlet;
+    position: relative;
+
+    .route-loader {
+      background-color: rgba(255, 255, 255, 0.4);
+      cursor: wait;
+      height: 100vh;
+      left: 0;
+      position: absolute;
+      top: 0;
+      width:  calc(100vw - 64px);
+      z-index: 10;
+
+      .spinner-container {
+        margin: calc(50vh - 3rem) auto;
+        width:  6rem;
+
+        svg {
+          color: $neutral-500;
+          font-size: 6rem;
+        }
+      }
+    }
   }
 
   sbdl-footer {
     grid-area: footer;
     max-width: 100%;
   }
+
 }
 
 @media only screen and (max-width: $breakpoint-sm) {
@@ -64,4 +88,6 @@
       display: none;
     }
   }
+
+  .route-loader { display: none; }
 }

--- a/webapp/src/app/layout/app-container/app-container.component.spec.ts
+++ b/webapp/src/app/layout/app-container/app-container.component.spec.ts
@@ -1,8 +1,8 @@
-import { APP_BASE_HREF, Location } from '@angular/common';
+import { Location } from '@angular/common';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { OktaAuthService } from '@okta/okta-angular';
+import { ActivatedRoute, Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { Observable, of } from 'rxjs';
 import { FooterComponent } from '../footer/footer.component';
 import { NavigationComponent } from '../navigation/navigation.component';
@@ -31,10 +31,9 @@ describe('AppContainerComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ AppContainerComponent, FooterComponent, NavigationComponent ],
-      imports: [ RouterTestingModule, SbdlCommonModule ],
+      imports: [ RouterTestingModule.withRoutes([]), SbdlCommonModule ],
       providers: [
         { provide: ActivatedRoute, useValue: mockRootActivatedRouteSnapshot },
-        { provide: APP_BASE_HREF, useValue: '/' },
         { provide: Location, useValue: { path: () => {} } },
         { provide: OktaAuthService, useClass: MockOktaAuthService },
         { provide: UserService, useClass: MockUserService }

--- a/webapp/src/app/layout/app-container/app-container.component.ts
+++ b/webapp/src/app/layout/app-container/app-container.component.ts
@@ -1,11 +1,53 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, NavigationStart, NavigationEnd, Router } from '@angular/router';
+import { Subject } from 'rxjs';
+import { debounceTime } from 'rxjs/operators';
 import { Location } from '@angular/common';
+import { urlPathPart } from 'src/app/common/utils';
+import { OKTA_CALLBACK_PATH } from 'src/app/common/constants';
 
 @Component({
   selector: 'sbdl-app-container',
   templateUrl: './app-container.component.html',
   styleUrls: ['./app-container.component.scss']
 })
-export class AppContainerComponent {
-  constructor(public location: Location) {}
+export class AppContainerComponent implements OnInit {
+  constructor(
+    private route: ActivatedRoute,
+    private location: Location,
+    private router: Router
+  ) {}
+
+  routeLoading = false;
+
+  private oldPath = '/';
+  private loading$ = new Subject<boolean>();
+
+  ngOnInit() {
+    this.router.events.subscribe((evt) => {
+      if (evt instanceof NavigationStart) {
+        this.loading$.next(true);
+      } else if (evt instanceof NavigationEnd) {
+        this.loading$.next(false);
+        const newPath = urlPathPart(evt.url);
+        if (newPath !== this.oldPath) {
+          window.scrollTo(0, 0);
+        }
+        this.oldPath = newPath;
+      }
+    });
+
+    this.route.fragment.subscribe((fragment) => {
+      if (fragment && !this.router.url.includes(OKTA_CALLBACK_PATH)) {
+        setTimeout(() => {
+          document.querySelector('#' + fragment).scrollIntoView({behavior: 'smooth'});
+        });
+      }
+    });
+
+    this.loading$
+      .pipe(debounceTime(250))
+      .subscribe(loading => this.routeLoading = loading);
+  }
+
 }

--- a/webapp/src/app/layout/app-container/app-container.component.ts
+++ b/webapp/src/app/layout/app-container/app-container.component.ts
@@ -20,6 +20,8 @@ export class AppContainerComponent implements OnInit {
 
   routeLoading = false;
 
+  get locationPath() { return this.location.path(); }
+
   private oldPath = '/';
   private loading$ = new Subject<boolean>();
 

--- a/webapp/src/app/search/results/search-results.component.html
+++ b/webapp/src/app/search/results/search-results.component.html
@@ -1,7 +1,6 @@
 <article id="main" class="results-container">
   <sbdl-search
     [filters]="filters"
-    [loading]="loading"
     [showAdvanced]="showAdvancedFiltersInitially"
     [numResults]="allResults.length"
     showingResults="true"

--- a/webapp/src/app/search/results/search-results.component.html
+++ b/webapp/src/app/search/results/search-results.component.html
@@ -1,9 +1,9 @@
 <article id="main" class="results-container">
   <sbdl-search
     [filters]="filters"
+    [showHeadings]="true"
     [showAdvanced]="showAdvancedFiltersInitially"
     [numResults]="allResults.length"
-    showingResults="true"
     (goToResults)="scrollToResults()"
   ></sbdl-search>
   <section #results class="search-results" width="120px" height="120px">

--- a/webapp/src/app/search/results/search-results.component.ts
+++ b/webapp/src/app/search/results/search-results.component.ts
@@ -24,17 +24,11 @@ export class SearchResultsComponent implements OnInit, OnDestroy {
 
   showAdvancedFiltersInitially: boolean;
 
-  loading = true;
-
   private dataSubscription: Subscription;
   private paramsSubscription: Subscription;
   private routerSubscription: Subscription;
 
   ngOnInit() {
-    this.routerSubscription = this.router.events
-      .pipe(filter(e => e instanceof NavigationStart))
-      .subscribe(() => { this.loading = true; });
-
     this.dataSubscription = this.route.data.subscribe(data => {
       if (data.results) {
         this.allResults = data.results.results || [];
@@ -73,7 +67,6 @@ export class SearchResultsComponent implements OnInit, OnDestroy {
   }
 
   chunkedRender = () => {
-    this.loading = false;
     if (this.renderedResults.length < this.allResults.length) {
       this.renderedResults.push(this.allResults[this.renderedResults.length]);
       requestAnimationFrame(this.chunkedRender);

--- a/webapp/src/app/search/results/search-results.resolve.ts
+++ b/webapp/src/app/search/results/search-results.resolve.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { SearchResults } from 'src/app/data/search/search-results.model';
 import { SearchService } from 'src/app/data/search/search.service';
 
@@ -8,13 +9,21 @@ import { SearchService } from 'src/app/data/search/search.service';
     providedIn: 'root'
 })
 export class SearchResultsResolve implements Resolve<SearchResults> {
-    constructor(private service: SearchService) { }
+  constructor(private service: SearchService) { }
 
-    resolve(route: ActivatedRouteSnapshot,
-            state: RouterStateSnapshot):
-            SearchResults | Observable<SearchResults> | Promise<SearchResults> {
+  resolve(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): SearchResults | Observable<SearchResults> | Promise<SearchResults> {
 
-        return this.service.fetchAllResults(this.service.paramsToRequestModel(route.params));
+    const searchParams = this.service.paramsToRequestModel(route.params);
+    // if we have no search params, don't do an expensive search over the entire index.
+    if (!searchParams) {
+      return this.service.getDefaultFilters().pipe(
+        map(filters => ({ filters, results: [] })));
+    } else {
+      return this.service.fetchAllResults(searchParams);
     }
+  }
 
 }

--- a/webapp/src/app/search/search.component.html
+++ b/webapp/src/app/search/search.component.html
@@ -1,3 +1,4 @@
+<h1 *ngIf="showHeadings && newSearch" class="new-search">Search for Resources </h1>
 <sbdl-text-field
   (submit)="search({query: $event})"
   [model]="filters.query"
@@ -5,14 +6,14 @@
   fontAwesomeIcon="fa-search">
 </sbdl-text-field>
 
-<div *ngIf="!showingResults" class="emphasis-medium caption browse-caption">
+<div *ngIf="newSearch" class="emphasis-medium caption browse-caption">
   Start typing a topic, claim, target, or <a href="javascript:void(0)" (click)="showAdvanced = true">browse for resources</a>.
 </div>
-<div *ngIf="showingResults" class="emphasis-medium caption filters-caption">
+<div *ngIf="!newSearch" class="emphasis-medium caption filters-caption">
   Start typing a topic, claim, target, or <a href="javascript:void(0);" (click)="showAdvanced = true">advanced search</a>.
 </div>
 
-<h1 *ngIf="showingResults" class="results-header">
+<h1 *ngIf="!newSearch" class="results-header">
   <span>
     Found {{ numResults }}
     <ng-container [ngPlural]="numResults" >
@@ -28,9 +29,16 @@
   </sbdl-button>
 </h1>
 
+<div *ngIf="showHeadings && newSearch" class="new-search">
+  Search for resources related to your search terms using the search input
+  above or click <a href="javascript:void(0)" (click)="showAdvanced = true">browse for resources</a>
+  to search for resources that exactly match your search criteria.
+</div>
+
+<div [hidden]="!showAdvanced || (!newSearch && numResults === 0)" class="advanced-search">
   <div class="advanced-header">
-      <h2 *ngIf="!showingResults">Browse for Resources</h2>
-      <h2 *ngIf="showingResults">Advanced Search</h2>
+      <h2 *ngIf="newSearch">Browse for Resources</h2>
+      <h2 *ngIf="!newSearch">Advanced Search</h2>
       <div>
         <a [routerLink]="['/search', {query: filters.query || ''}]"
            class="emphasis-medium caption">

--- a/webapp/src/app/search/search.component.html
+++ b/webapp/src/app/search/search.component.html
@@ -28,10 +28,6 @@
   </sbdl-button>
 </h1>
 
-<div [hidden]="!showAdvanced || numResults === 0" class="advanced-search">
-  <div class="loading-overlay" [attr.aria-hidden]="loading" [ngClass]="{loading: loading}">
-    <div>Loading...</div>
-  </div>
   <div class="advanced-header">
       <h2 *ngIf="!showingResults">Browse for Resources</h2>
       <h2 *ngIf="showingResults">Advanced Search</h2>

--- a/webapp/src/app/search/search.component.scss
+++ b/webapp/src/app/search/search.component.scss
@@ -64,34 +64,6 @@
       0px 3px 14px rgba(0, 0, 0, 0.12),
       0px 8px 10px rgba(0, 0, 0, 0.14);
 
-    .loading-overlay {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      right: 0;
-
-      text-align: center;
-      padding-top: 45%;
-      cursor: wait;
-      background-color: rgba(255, 255, 255, 0.7);
-      opacity: 0;
-      z-index: -1;
-      transition: opacity 0.5s linear, z-index 1s linear;
-
-      &.loading {
-        opacity: 1;
-        z-index: 20;
-      }
-
-      div {
-        background-color: rgba(255, 255, 255, 0.5);
-        color: $neutral-700;
-        font-size: $font-size-4;
-        font-family: $font-family-title;
-      }
-    }
-
     .advanced-header {
       display: flex;
       align-items: baseline;

--- a/webapp/src/app/search/search.component.scss
+++ b/webapp/src/app/search/search.component.scss
@@ -38,6 +38,16 @@
     margin-left: $spacer-md;
   }
 
+  h1.new-search {
+    color: $brand-green;
+    font-size: $font-size-7;
+  }
+
+  div.new-search {
+    font-size: $font-size-2;
+    margin: $spacer-lg $spacer;
+  }
+
   h1.results-header {
     align-items: center;
     color: $brand-blue;

--- a/webapp/src/app/search/search.component.ts
+++ b/webapp/src/app/search/search.component.ts
@@ -36,15 +36,16 @@ export class SearchComponent implements  AfterViewInit, OnInit, OnDestroy {
   showAdvanced = false;
 
   @Input()
-  showingResults = false;
+  numResults: number;
 
   @Input()
-  numResults: number;
+  showHeadings = true;
 
   @Output()
   goToResults = new EventEmitter<boolean>();
 
   params: SearchQueryParams;
+  newSearch = true;
 
   private routerSubscription: Subscription;
 
@@ -52,11 +53,13 @@ export class SearchComponent implements  AfterViewInit, OnInit, OnDestroy {
 
   ngOnInit() {
     this.params = this.rectifyParams(this.parseParams(this.route.snapshot.params || {}));
+    this.newSearch = (Object.keys(this.params).length === 0);
 
     this.routerSubscription = this.router.events
       .pipe(filter(e => e instanceof NavigationEnd))
       .subscribe(() => {
         this.params = this.rectifyParams(this.parseParams(this.route.snapshot.params || {}));
+        this.newSearch = (Object.keys(this.params).length === 0);
       });
   }
 

--- a/webapp/src/app/search/search.component.ts
+++ b/webapp/src/app/search/search.component.ts
@@ -41,9 +41,6 @@ export class SearchComponent implements  AfterViewInit, OnInit, OnDestroy {
   @Input()
   numResults: number;
 
-  @Input()
-  loading = false;
-
   @Output()
   goToResults = new EventEmitter<boolean>();
 
@@ -115,7 +112,6 @@ export class SearchComponent implements  AfterViewInit, OnInit, OnDestroy {
   }
 
   search(newParams: SearchQueryParams) {
-    this.loading = true;
     const params = this.rectifyParams({...this.params, ...newParams });
 
     this.router.navigate(['search', params]);


### PR DESCRIPTION
* Added an application-wide loading spinner as part of AppContainerComponent. Listens to routing events and shows/hides the loader. Loader presentation is debounced, so the loader will not flash and disappear if the navigation takes less than 250ms to complete.
* SearchComponent now has some option UI behind the `showHeading` input attribute that allows us to show a nice "starting search" page in stead of "Found 0 results" if the user lands on `/search`  with no search params.
* SearchResultsResolver now refuses to do a search if there are no search params. Instead it returns the initial filter set loaded from SearchService and an empty resultset.