### PR TITLE
T4T-830 - Include the items path for print redirect

### DIFF
--- a/webapp/src/app/app-routing.module.ts
+++ b/webapp/src/app/app-routing.module.ts
@@ -78,6 +78,9 @@ const routes: Routes = [
       }, { 
         path: 'playlist',
         redirectTo: '/landing/playlist',
+      }, { 
+        path: 'items',
+        redirectTo: '/landing/items',
       }, {
         path: OKTA_CALLBACK_PATH,
         component: LoginCallbackComponent


### PR DESCRIPTION
From Ipsita:
While testing story 830, I found that "https://qa.webapp.dl.smarterbalanced.org/items" is showing 404 error.
"https://qa.webapp.dl.smarterbalanced.org/items" is expected to redirect  to "https://qa.webapp.dl.smarterbalanced.org/landing/items" like other resources.